### PR TITLE
change unknown to unreached

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 -   repo: https://github.com/CanalTP/asgard.git
-    rev: v1.00
+    rev: v1.0.0
     hooks:
     -   id: clang-format

--- a/asgard/asgard.cpp
+++ b/asgard/asgard.cpp
@@ -111,10 +111,8 @@ struct AsgardConf {
 
         reachability = valhalla_conf.get<unsigned int>("loki.service_defaults.minimum_reachability", 0);
         radius = valhalla_conf.get<unsigned int>("loki.service_defaults.radius", 0);
-
     }
 };
-
 
 int main() {
     AsgardConf asgard_conf{};

--- a/asgard/asgard.cpp
+++ b/asgard/asgard.cpp
@@ -91,7 +91,7 @@ const T get_config(const std::string& key, T value = T()) {
 }
 
 namespace ptree = boost::property_tree;
-struct AsgardConf{
+struct AsgardConf {
     std::string socket_path;
     std::size_t cache_size;
     std::size_t nb_threads;
@@ -109,8 +109,8 @@ struct AsgardConf{
         auto valhalla_conf_json = get_config<std::string>("ASGARD_VALHALLA_CONF", "/data/valhalla/valhalla.json");
         ptree::read_json(valhalla_conf_json, valhalla_conf);
 
-        reachability = valhalla_conf.get<unsigned int>("loki.service_defaults.minimum_reachability" , 0);
-        radius = valhalla_conf.get<unsigned int>("loki.service_defaults.radius" , 0);
+        reachability = valhalla_conf.get<unsigned int>("loki.service_defaults.minimum_reachability", 0);
+        radius = valhalla_conf.get<unsigned int>("loki.service_defaults.radius", 0);
 
     }
 };

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -80,9 +80,9 @@ pbnavitia::Response Handler::handle(const pbnavitia::Request& request) {
 namespace pt = boost::posix_time;
 pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
     pt::ptime start = pt::microsec_clock::universal_time();
-    LOG_INFO(util::string_format("Processing matrix request %d x %d",
-             request.sn_routing_matrix().origins_size
-             request.sn_routing_matrix().destinations_size()));
+    LOG_INFO("Processing matrix request " +
+             std::to_string(request.sn_routing_matrix().origins_size()) + "x" +
+             std::to_string(request.sn_routing_matrix().destinations_size()));
     const std::string mode = request.sn_routing_matrix().mode();
     std::vector<std::string> sources;
     sources.reserve(request.sn_routing_matrix().origins_size());
@@ -100,7 +100,7 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
     mode_costing.update_costing_for_mode(mode, request.sn_routing_matrix().speed());
     auto costing = mode_costing.get_costing_for_mode(mode);
 
-    LOG_INFO(util::string_format("Projecting %d locations...", sources.size() + targets.size()));
+    LOG_INFO("Projecting " + std::to_string(sources.size() + targets.size()) + " locations...");
     auto range = boost::range::join(sources, targets);
     auto path_locations = projector(begin(range), end(range), graph, mode, costing);
     LOG_INFO("Projecting locations done.");
@@ -140,7 +140,7 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
         }
     }
 
-    LOG_INFO(util::string_format("Request done with %d unreached", nb_unreached));
+    LOG_INFO("Request done with " + std::to_string(nb_unreached) + " unreached");
 
     if (graph.OverCommitted()) { graph.Clear(); }
     LOG_INFO("Everything is clear.");

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -15,7 +15,9 @@ namespace {
 valhalla::baldr::Location build_location(const std::string& place) {
     auto coord = navitia::parse_coordinate(place);
     auto l = valhalla::baldr::Location({coord.first, coord.second},
-                                       valhalla::baldr::Location::StopType::BREAK);
+                                       valhalla::baldr::Location::StopType::BREAK,
+                                       0,
+                                       20);
     l.name_ = place;
     return l;
 }

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -12,12 +12,14 @@
 namespace asgard {
 
 namespace {
-valhalla::baldr::Location build_location(const std::string& place) {
+valhalla::baldr::Location build_location(const std::string& place,
+                                         unsigned int reachability,
+                                         unsigned int radius) {
     auto coord = navitia::parse_coordinate(place);
     auto l = valhalla::baldr::Location({coord.first, coord.second},
                                        valhalla::baldr::Location::StopType::BREAK,
-                                       0,
-                                       20);
+                                       reachability,
+                                       radius);
     l.name_ = place;
     return l;
 }
@@ -39,6 +41,9 @@ private:
     // maximal cached values
     size_t cache_size;
 
+    unsigned int reachability;
+    unsigned int radius;
+
     // the cache, mutable because side effect are not visible from the
     // exterior because of the purity of f
     mutable Cache cache;
@@ -47,7 +52,11 @@ private:
     mutable std::mutex mutex;
 
 public:
-    Projector(size_t cache_size = 1000) : cache_size(cache_size) {}
+    Projector(size_t cache_size = 1000,
+              unsigned int reachability = 0 ,
+              unsigned int radius = 0) : cache_size(cache_size),
+                                         reachability(reachability),
+                                         radius(radius){}
 
     template<typename T>
     std::unordered_map<std::string, valhalla::baldr::PathLocation>
@@ -71,7 +80,7 @@ public:
                     results.emplace(*it, search->second);
                 } else {
                     ++nb_cache_miss;
-                    missed.push_back(build_location(*it));
+                    missed.push_back(build_location(*it, reachability, radius));
                 }
             }
         }

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -53,10 +53,10 @@ private:
 
 public:
     Projector(size_t cache_size = 1000,
-              unsigned int reachability = 0 ,
+              unsigned int reachability = 0,
               unsigned int radius = 0) : cache_size(cache_size),
                                          reachability(reachability),
-                                         radius(radius){}
+                                         radius(radius) {}
 
     template<typename T>
     std::unordered_map<std::string, valhalla::baldr::PathLocation>

--- a/asgard/util.h
+++ b/asgard/util.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <memory>
-#include <cstdio>
-
 #include "asgard/response.pb.h"
 #include <valhalla/proto/directions_options.pb.h>
 
@@ -23,16 +20,6 @@ valhalla::sif::TravelMode convert_navitia_to_valhalla_mode(const std::string& mo
 size_t navitia_to_valhalla_mode_index(const std::string& mode);
 
 valhalla::odin::Costing convert_navitia_to_valhalla_costing(const std::string& costing);
-
-template<typename ... Args>
-std::string string_format( const std::string& format, Args ... args )
-{
-    size_t size = std::snprintf(nullptr, 0, format.c_str(), args ...) + 1; // Extra space for '\0'
-    std::unique_ptr<char[]> buf( new char[ size ] );
-    std::snprintf( buf.get(), size, format.c_str(), args ... );
-    return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
-}
-
 } // namespace util
 
 } // namespace asgard

--- a/asgard/util.h
+++ b/asgard/util.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <cstdio>
+
 #include "asgard/response.pb.h"
 #include <valhalla/proto/directions_options.pb.h>
 
@@ -20,6 +23,16 @@ valhalla::sif::TravelMode convert_navitia_to_valhalla_mode(const std::string& mo
 size_t navitia_to_valhalla_mode_index(const std::string& mode);
 
 valhalla::odin::Costing convert_navitia_to_valhalla_costing(const std::string& costing);
+
+template<typename ... Args>
+std::string string_format( const std::string& format, Args ... args )
+{
+    size_t size = std::snprintf(nullptr, 0, format.c_str(), args ...) + 1; // Extra space for '\0'
+    std::unique_ptr<char[]> buf( new char[ size ] );
+    std::snprintf( buf.get(), size, format.c_str(), args ... );
+    return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
+}
+
 } // namespace util
 
 } // namespace asgard


### PR DESCRIPTION
What happened with this `unknown` status is that in distributed scenario, jormun will create a crow fly section if a stop_point's status is `unknown` in the matrix, since the crow fly is super rapid, the journey with crow fly will win over all other realistic journeys. 

The `unknown` status in the matrix is actually  meaningless. From the point of view of traveler, there is no difference between `unknown` and `unreached` **when the calculator of street netrwork is asgard**. 

The `unknown` status in kraken is more meaningful because kraken may not have street network data in some coverage, in this case, a crow fly is useful    