### PR TITLE
fix incoherent time between matrix and direct path

### DIFF
--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -65,7 +65,6 @@ pbnavitia::Response build_journey_response(const pbnavitia::Request& request,
 
     set_extremity_pt_object(list_geo_points.front(), s->mutable_origin());
     set_extremity_pt_object(list_geo_points.back(), s->mutable_destination());
-
     compute_geojson(list_geo_points, *s);
 
     compute_metadata(*journey);
@@ -144,6 +143,8 @@ void compute_metadata(pbnavitia::Journey& pb_journey) {
     distances->set_bike(total_bike_distance);
     distances->set_car(total_car_distance);
     distances->set_ridesharing(total_ridesharing_distance);
+
+    pb_journey.set_duration(ts_arrival - ts_departure);
 }
 } // namespace direct_path_response_builder
 

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -151,14 +151,14 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
     return response;
 }
 
-thor::PathAlgorithm* Handler::get_path_algorithm(const std::string& mode) {
+thor::PathAlgorithm& Handler::get_path_algorithm(const std::string& mode) {
     // We use astar for walking to avoid differences between
     // The time from the matrix and the one from the direct_path
     if (mode == "walking") {
-        return &astar;
+        return astar;
     }
 
-    return &bda;
+    return bda;
 }
 
 pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& request) {
@@ -182,14 +182,14 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
     baldr::PathLocation::toPBF(path_locations.at(locations.front()), &origin, graph);
     baldr::PathLocation::toPBF(path_locations.at(locations.back()), &dest, graph);
 
-    thor::PathAlgorithm* algo = get_path_algorithm(mode);
+    auto& algo = get_path_algorithm(mode);
 
     LOG_INFO("Computing best path...");
-    const auto path_info_list = algo->GetBestPath(origin,
-                                                  dest,
-                                                  graph,
-                                                  mode_costing.get_costing(),
-                                                  util::convert_navitia_to_valhalla_mode(mode));
+    const auto path_info_list = algo.GetBestPath(origin,
+                                                 dest,
+                                                 graph,
+                                                 mode_costing.get_costing(),
+                                                 util::convert_navitia_to_valhalla_mode(mode));
     LOG_INFO("Computing best path done.");
 
     // If no solution was found
@@ -207,7 +207,7 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
     const auto response = direct_path_response_builder::build_journey_response(request, path_info_list, trip_path);
 
     if (graph.OverCommitted()) { graph.Clear(); }
-    algo->Clear();
+    algo.Clear();
     LOG_INFO("Everything is clear.");
 
     auto duration = pt::microsec_clock::universal_time() - start;

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -157,7 +157,7 @@ thor::PathAlgorithm* Handler::get_path_algorithm(const std::string& mode) {
     if (mode == "walking") {
         return &astar;
     }
-    
+
     return &bda;
 }
 
@@ -185,11 +185,11 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
     thor::PathAlgorithm* algo = get_path_algorithm(mode);
 
     LOG_INFO("Computing best path...");
-    auto const path_info_list = algo->GetBestPath(origin,
-                                          dest,
-                                          graph,
-                                          mode_costing.get_costing(),
-                                          util::convert_navitia_to_valhalla_mode(mode));
+    const auto path_info_list = algo->GetBestPath(origin,
+                                                  dest,
+                                                  graph,
+                                                  mode_costing.get_costing(),
+                                                  util::convert_navitia_to_valhalla_mode(mode));
     LOG_INFO("Computing best path done.");
 
     // If no solution was found
@@ -201,10 +201,10 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
     }
 
     thor::AttributesController controller;
-    auto const trip_path = thor::TripPathBuilder::Build(controller, graph, mode_costing.get_costing(), path_info_list, origin,
+    const auto trip_path = thor::TripPathBuilder::Build(controller, graph, mode_costing.get_costing(), path_info_list, origin,
                                                         dest, {origin, dest});
 
-    auto const response = direct_path_response_builder::build_journey_response(request, path_info_list, trip_path);
+    const auto response = direct_path_response_builder::build_journey_response(request, path_info_list, trip_path);
 
     if (graph.OverCommitted()) { graph.Clear(); }
     algo->Clear();

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -143,11 +143,22 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
     LOG_INFO("Request done with " + std::to_string(nb_unreached) + " unreached");
 
     if (graph.OverCommitted()) { graph.Clear(); }
+    matrix.Clear();
     LOG_INFO("Everything is clear.");
 
     auto duration = pt::microsec_clock::universal_time() - start;
     metrics.observe_handle_matrix(mode, duration.total_milliseconds() / 1000.0);
     return response;
+}
+
+thor::PathAlgorithm* Handler::get_path_algorithm(const std::string& mode) {
+    // We use astar for walking to avoid differences between
+    // The time from the matrix and the one from the direct_path
+    if (mode == "walking") {
+        return &astar;
+    }
+    
+    return &bda;
 }
 
 pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& request) {
@@ -171,8 +182,10 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
     baldr::PathLocation::toPBF(path_locations.at(locations.front()), &origin, graph);
     baldr::PathLocation::toPBF(path_locations.at(locations.back()), &dest, graph);
 
+    thor::PathAlgorithm* algo = get_path_algorithm(mode);
+
     LOG_INFO("Computing best path...");
-    auto path_info_list = bda.GetBestPath(origin,
+    auto const path_info_list = algo->GetBestPath(origin,
                                           dest,
                                           graph,
                                           mode_costing.get_costing(),
@@ -187,15 +200,14 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
         return response;
     }
 
-    // To compute the length
-    // Can disable all options except the length here
     thor::AttributesController controller;
-    auto trip_path = thor::TripPathBuilder::Build(controller, graph, mode_costing.get_costing(), path_info_list, origin,
-                                                  dest, {origin, dest});
+    auto const trip_path = thor::TripPathBuilder::Build(controller, graph, mode_costing.get_costing(), path_info_list, origin,
+                                                        dest, {origin, dest});
 
-    auto response = direct_path_response_builder::build_journey_response(request, path_info_list, trip_path);
+    auto const response = direct_path_response_builder::build_journey_response(request, path_info_list, trip_path);
 
     if (graph.OverCommitted()) { graph.Clear(); }
+    algo->Clear();
     LOG_INFO("Everything is clear.");
 
     auto duration = pt::microsec_clock::universal_time() - start;

--- a/asgard/handler.h
+++ b/asgard/handler.h
@@ -41,7 +41,7 @@ private:
     pbnavitia::Response handle_matrix(const pbnavitia::Request&);
     pbnavitia::Response handle_direct_path(const pbnavitia::Request&);
 
-    valhalla::thor::PathAlgorithm* get_path_algorithm(const std::string& mode);
+    valhalla::thor::PathAlgorithm& get_path_algorithm(const std::string& mode);
 
     valhalla::baldr::GraphReader graph;
     valhalla::thor::TimeDistanceMatrix matrix;

--- a/asgard/handler.h
+++ b/asgard/handler.h
@@ -41,9 +41,12 @@ private:
     pbnavitia::Response handle_matrix(const pbnavitia::Request&);
     pbnavitia::Response handle_direct_path(const pbnavitia::Request&);
 
+    valhalla::thor::PathAlgorithm* get_path_algorithm(const std::string& mode);
+
     valhalla::baldr::GraphReader graph;
     valhalla::thor::TimeDistanceMatrix matrix;
     valhalla::thor::BidirectionalAStar bda;
+    valhalla::thor::AStarPathAlgorithm astar;
     ModeCosting mode_costing;
     const Projector& projector;
     const Metrics& metrics;

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -11,22 +11,10 @@
 
 namespace asgard {
 
-namespace {
-valhalla::baldr::Location build_location(const std::string& place,
-                                         unsigned int reachability,
-                                         unsigned int radius) {
-    auto coord = navitia::parse_coordinate(place);
-    auto l = valhalla::baldr::Location({coord.first, coord.second},
-                                       valhalla::baldr::Location::StopType::BREAK,
-                                       reachability,
-                                       radius);
-    l.name_ = place;
-    return l;
-}
-} // namespace
-
 class Projector {
 private:
+    friend class UnitTestProjector;
+
     typedef std::pair<std::string, std::string> key_type;
     typedef valhalla::baldr::PathLocation mapped_type;
     typedef std::pair<const key_type, mapped_type> value_type;
@@ -50,6 +38,18 @@ private:
     mutable size_t nb_cache_miss = 0;
     mutable size_t nb_calls = 0;
     mutable std::mutex mutex;
+
+    valhalla::baldr::Location build_location(const std::string& place,
+                                             unsigned int reachability,
+                                             unsigned int radius) const {
+        auto coord = navitia::parse_coordinate(place);
+        auto l = valhalla::baldr::Location({coord.first, coord.second},
+                                           valhalla::baldr::Location::StopType::BREAK,
+                                           reachability,
+                                           radius);
+        l.name_ = place;
+        return l;
+    }
 
 public:
     Projector(size_t cache_size = 1000,


### PR DESCRIPTION
This PR fixes the weird results we had requesting the same requests multiple times by clear the cache in the algorithms (bi-astar and astar) and in the matrix.
It also fixes the difference of time we had between the matrix and the direct_path using the astar for the mode "walking". 