### PR TITLE
Using global_synchronized_cache to have one instance of graph in the application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
     SET(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 
-SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=thread")
+SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer")
 
 # Load in the needed CMake modules
 include(UseBoost)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
     SET(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 
-SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer")
+SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=thread")
 
 # Load in the needed CMake modules
 include(UseBoost)

--- a/asgard/asgard.cpp
+++ b/asgard/asgard.cpp
@@ -127,7 +127,6 @@ int main() {
                                       asgard_conf.radius);
     valhalla::baldr::GraphReader graph(asgard_conf.valhalla_conf.get_child("mjolnir"));
 
-
     for (size_t i = 0; i < asgard_conf.nb_threads; ++i) {
         threads.create_thread(std::bind(&worker, asgard::Context(context,
                                                                  graph,

--- a/asgard/asgard.cpp
+++ b/asgard/asgard.cpp
@@ -125,10 +125,12 @@ int main() {
     const asgard::Projector projector(asgard_conf.cache_size,
                                       asgard_conf.reachability,
                                       asgard_conf.radius);
+    valhalla::baldr::GraphReader graph(asgard_conf.valhalla_conf.get_child("mjolnir"));
+
 
     for (size_t i = 0; i < asgard_conf.nb_threads; ++i) {
         threads.create_thread(std::bind(&worker, asgard::Context(context,
-                                                                 asgard_conf.valhalla_conf,
+                                                                 graph,
                                                                  metrics,
                                                                  projector)));
     }

--- a/asgard/context.h
+++ b/asgard/context.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <valhalla/baldr/graphreader.h>
+
 #include <boost/property_tree/ptree.hpp>
 
 namespace zmq {
@@ -29,13 +31,13 @@ class Projector;
 
 struct Context {
     zmq::context_t& zmq_context;
-    boost::property_tree::ptree ptree;
+    valhalla::baldr::GraphReader& graph;
     const Metrics& metrics;
     const Projector& projector;
 
-    Context(zmq::context_t& zmq_context, boost::property_tree::ptree ptree,
+    Context(zmq::context_t& zmq_context, valhalla::baldr::GraphReader& graph,
             const Metrics& metrics, const Projector& projector) : zmq_context(zmq_context),
-                                                                  ptree(ptree),
+                                                                  graph(graph),
                                                                   metrics(metrics),
                                                                   projector(projector) {}
 };

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -62,7 +62,7 @@ static double get_speed_request(const pbnavitia::Request& request, const std::st
     }
 }
 
-Handler::Handler(const Context& context) : graph(context.ptree.get_child("mjolnir")),
+Handler::Handler(const Context& context) : graph(context.graph),
                                            matrix(),
                                            mode_costing(),
                                            metrics(context.metrics),

--- a/asgard/handler.h
+++ b/asgard/handler.h
@@ -43,7 +43,7 @@ private:
 
     valhalla::thor::PathAlgorithm& get_path_algorithm(const std::string& mode);
 
-    valhalla::baldr::GraphReader graph;
+    valhalla::baldr::GraphReader& graph;
     valhalla::thor::TimeDistanceMatrix matrix;
     valhalla::thor::BidirectionalAStar bda;
     valhalla::thor::AStarPathAlgorithm astar;

--- a/docker/asgard-data/Dockerfile
+++ b/docker/asgard-data/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       tar
 
 # Download the pbf given in argument
-ARG pbf_url=http://download.geofabrik.de/europe/france/ile-de-france-latest.osm.pbf
+ARG pbf_url=http://download.geofabrik.de/europe/france-latest.osm.pbf
 RUN wget --progress=bar:force:noscroll $pbf_url \
   && mkdir -p valhalla_tiles \
   && valhalla_build_config --mjolnir-tile-dir ${PWD}/valhalla_tiles --mjolnir-tile-extract ${PWD}/valhalla_tiles.tar --mjolnir-timezone ${PWD}/valhalla_tiles/timezones.sqlite --mjolnir-admin ${PWD}/valhalla_tiles/admins.sqlite > valhalla.json \

--- a/docker/asgard-data/Dockerfile
+++ b/docker/asgard-data/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       tar
 
 # Download the pbf given in argument
-ARG pbf_url=http://download.geofabrik.de/europe/france-latest.osm.pbf
+ARG pbf_url=http://download.geofabrik.de/europe/france/ile-de-france-latest.osm.pbf
 RUN wget --progress=bar:force:noscroll $pbf_url \
   && mkdir -p valhalla_tiles \
   && valhalla_build_config --mjolnir-tile-dir ${PWD}/valhalla_tiles --mjolnir-tile-extract ${PWD}/valhalla_tiles.tar --mjolnir-timezone ${PWD}/valhalla_tiles/timezones.sqlite --mjolnir-admin ${PWD}/valhalla_tiles/admins.sqlite > valhalla.json \
@@ -17,6 +17,8 @@ RUN wget --progress=bar:force:noscroll $pbf_url \
   && sed -i 's,\"radius\"\: [[:digit:]]*,\"radius\"\: 30,' valhalla.json \
   && sed -i 's,\"shortcuts\"\: [^,]*,\"shortcuts\"\: false,' valhalla.json \
   && sed -i 's,\"hierarchy\"\: [^,]*,\"hierarchy\"\: false,' valhalla.json \
+  # Make the graph shareable between threads in a thread-safe way
+  && sed -i '/"hierarchy":/a \\t"global_synchronized_cache": true,' valhalla.json \
   && valhalla_build_tiles -c valhalla.json *.pbf \
   && find valhalla_tiles | sort -n | tar cf valhalla_tiles.tar --no-recursion -T -
 


### PR DESCRIPTION
I've checked with implementation with thread sanitizer and the benchmark in this repo. The graph is indeed thread-safe without any loss in performance.