### PR TITLE
Adding cycle_path_type for PathItems in response

### DIFF
--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -158,6 +158,7 @@ void compute_path_items(const odin::TripPath& trip_path, pbnavitia::StreetNetwor
         auto const& e = n.edge();
         set_path_item_name(e, *path_item);
         set_path_item_length(e, *path_item);
+        set_path_item_type(e, *path_item);
         previous_node_elapsed_time = set_path_item_duration(n, previous_node_elapsed_time, *path_item);
     }
 }
@@ -171,6 +172,13 @@ void set_path_item_name(const odin::TripPath_Edge& edge, pbnavitia::PathItem& pa
 void set_path_item_length(const odin::TripPath_Edge& edge, pbnavitia::PathItem& path_item) {
     if (edge.has_length()) {
         path_item.set_length(edge.length() * KM_TO_M);
+    }
+}
+
+// For now, we only handle cycle lanes
+void set_path_item_type(const valhalla::odin::TripPath_Edge& edge, pbnavitia::PathItem& path_item) {
+    if (edge.has_cycle_lane()) {
+        path_item.set_cycle_path_type(util::convert_valhalla_to_navitia_cycle_lane(edge.cycle_lane()));
     }
 }
 

--- a/asgard/direct_path_response_builder.h
+++ b/asgard/direct_path_response_builder.h
@@ -39,7 +39,7 @@ void compute_path_items(const valhalla::odin::TripPath& trip_path, pbnavitia::St
 
 void set_path_item_name(const valhalla::odin::TripPath_Edge& edge, pbnavitia::PathItem& path_item);
 void set_path_item_length(const valhalla::odin::TripPath_Edge& edge, pbnavitia::PathItem& path_item);
-//void set_path_item_type(const valhalla::odin::TripPath_Edge& edge, pbnavitia::PathItem& path_item); @TODO
+void set_path_item_type(const valhalla::odin::TripPath_Edge& edge, pbnavitia::PathItem& path_item);
 uint32_t set_path_item_duration(const valhalla::odin::TripPath_Node& node, uint32_t previous_node_elapsed_time, pbnavitia::PathItem& path_item);
 
 } // namespace direct_path_response_builder

--- a/asgard/tests/direct_path_response_builder_test.cpp
+++ b/asgard/tests/direct_path_response_builder_test.cpp
@@ -314,6 +314,35 @@ BOOST_AUTO_TEST_CASE(set_path_item_length_test) {
     }
 }
 
+void set_and_check_cycle_path_type(const odin::TripPath::CycleLane& valhalla_cycle_lane, const pbnavitia::CyclePathType& expected_navitia_type) {
+    odin::TripPath_Node node;
+    auto edge = node.mutable_edge();
+    edge->set_cycle_lane(valhalla_cycle_lane);
+    auto path_item = pbnavitia::PathItem();
+
+    set_path_item_type(*edge, path_item);
+    BOOST_CHECK_EQUAL(path_item.has_cycle_path_type(), true);
+    BOOST_CHECK_EQUAL(path_item.cycle_path_type(), expected_navitia_type);
+}
+
+BOOST_AUTO_TEST_CASE(set_path_item_type_test) {
+    // No value set in path_item
+    {
+        odin::TripPath_Node node;
+        auto edge = node.mutable_edge();
+        auto path_item = pbnavitia::PathItem();
+
+        set_path_item_type(*edge, path_item);
+        BOOST_CHECK_EQUAL(path_item.cycle_path_type(), false);
+    }
+
+    // One value set in path_item
+    set_and_check_cycle_path_type(odin::TripPath_CycleLane_kNoCycleLane, pbnavitia::NoCycleLane);
+    set_and_check_cycle_path_type(odin::TripPath_CycleLane_kShared, pbnavitia::SharedCycleWay);
+    set_and_check_cycle_path_type(odin::TripPath_CycleLane_kDedicated, pbnavitia::DedicatedCycleWay);
+    set_and_check_cycle_path_type(odin::TripPath_CycleLane_kSeparated, pbnavitia::SeparatedCycleWay);
+}
+
 // Create a node and set its elapsed_time with node_elapsed_time
 // Checks that the value in path_item.duration() is node_elapsed_time - previous
 // And set_path_item_duration return value is node_elapsed_time

--- a/asgard/tests/util_test.cpp
+++ b/asgard/tests/util_test.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(convert_valhalla_to_navitia_cycle_lane_test) {
     BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kShared), pbnavitia::SharedCycleWay);
     BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kDedicated), pbnavitia::DedicatedCycleWay);
     BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kSeparated), pbnavitia::SeparatedCycleWay);
-    BOOST_CHECK_THROW(convert_valhalla_to_navitia_cycle_lane(static_cast<odin::TripPath::CycleLane>(42)), std::invalid_argument);
+    BOOST_CHECK_NO_THROW(convert_valhalla_to_navitia_cycle_lane(static_cast<odin::TripPath::CycleLane>(42)));
 }
 
 } // namespace util

--- a/asgard/tests/util_test.cpp
+++ b/asgard/tests/util_test.cpp
@@ -42,6 +42,14 @@ BOOST_AUTO_TEST_CASE(convert_navitia_to_valhalla_costing_test) {
     BOOST_CHECK_THROW(convert_navitia_to_valhalla_costing("plopi"), std::out_of_range);
 }
 
+BOOST_AUTO_TEST_CASE(convert_valhalla_to_navitia_cycle_lane_test) {
+    BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kNoCycleLane), pbnavitia::NoCycleLane);
+    BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kShared), pbnavitia::SharedCycleWay);
+    BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kDedicated), pbnavitia::DedicatedCycleWay);
+    BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kSeparated), pbnavitia::SeparatedCycleWay);
+    BOOST_CHECK_THROW(convert_valhalla_to_navitia_cycle_lane(static_cast<odin::TripPath::CycleLane>(42)), std::invalid_argument);
+}
+
 } // namespace util
 
 } // namespace asgard

--- a/asgard/util.cpp
+++ b/asgard/util.cpp
@@ -65,7 +65,7 @@ pbnavitia::CyclePathType convert_valhalla_to_navitia_cycle_lane(const odin::Trip
         return pbnavitia::SeparatedCycleWay;
 
     default:
-        throw std::invalid_argument("Bad convert_valhalla_to_navitia_cycle_lane parameter");
+        LOG_WARN("Unknown convert_valhalla_to_navitia_cycle_lane parameter. Value = " + std::to_string(cycle_lane));
     }
 }
 

--- a/asgard/util.cpp
+++ b/asgard/util.cpp
@@ -50,6 +50,25 @@ odin::Costing convert_navitia_to_valhalla_costing(const std::string& costing) {
     return navitia_to_valhalla_costing_map.at(costing);
 }
 
+pbnavitia::CyclePathType convert_valhalla_to_navitia_cycle_lane(const odin::TripPath::CycleLane& cycle_lane) {
+    switch (cycle_lane) {
+    case odin::TripPath_CycleLane_kNoCycleLane:
+        return pbnavitia::NoCycleLane;
+
+    case odin::TripPath_CycleLane_kShared:
+        return pbnavitia::SharedCycleWay;
+
+    case odin::TripPath_CycleLane_kDedicated:
+        return pbnavitia::DedicatedCycleWay;
+
+    case odin::TripPath_CycleLane_kSeparated:
+        return pbnavitia::SeparatedCycleWay;
+
+    default:
+        throw std::invalid_argument("Bad convert_valhalla_to_navitia_cycle_lane parameter");
+    }
+}
+
 } // namespace util
 
 } // namespace asgard

--- a/asgard/util.h
+++ b/asgard/util.h
@@ -2,6 +2,7 @@
 
 #include "asgard/response.pb.h"
 #include <valhalla/proto/directions_options.pb.h>
+#include <valhalla/thor/trippathbuilder.h>
 
 namespace valhalla {
 namespace sif {
@@ -20,6 +21,8 @@ valhalla::sif::TravelMode convert_navitia_to_valhalla_mode(const std::string& mo
 size_t navitia_to_valhalla_mode_index(const std::string& mode);
 
 valhalla::odin::Costing convert_navitia_to_valhalla_costing(const std::string& costing);
+
+pbnavitia::CyclePathType convert_valhalla_to_navitia_cycle_lane(const valhalla::odin::TripPath::CycleLane& cycle_lane);
 } // namespace util
 
 } // namespace asgard


### PR DESCRIPTION
We want to print in navitia the percentage of cycle lane used in bike.

For each path item, we have to fill the information of what kind of cycle_lane it is.