### PR TITLE
Fix taxi warning in compute_metadata

### DIFF
--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -101,10 +101,13 @@ void compute_metadata(pbnavitia::Journey& pb_journey) {
     uint32_t total_car_duration = 0;
     uint32_t total_bike_duration = 0;
     uint32_t total_ridesharing_duration = 0;
+    uint32_t total_taxi_duration = 0;
+
     uint32_t total_walking_distance = 0;
     uint32_t total_car_distance = 0;
     uint32_t total_bike_distance = 0;
     uint32_t total_ridesharing_distance = 0;
+    uint32_t total_taxi_distance = 0;
 
     for (const auto& section : pb_journey.sections()) {
         if (section.type() == pbnavitia::STREET_NETWORK || section.type() == pbnavitia::CROW_FLY) {
@@ -127,6 +130,10 @@ void compute_metadata(pbnavitia::Journey& pb_journey) {
                 total_ridesharing_duration += section.duration();
                 total_ridesharing_distance += section.length();
                 break;
+            case pbnavitia::StreetNetworkMode::Taxi:
+                total_taxi_duration += section.duration();
+                total_taxi_distance += section.length();
+                break;
             }
         } else if (section.type() == pbnavitia::TRANSFER && section.transfer_type() == pbnavitia::walking) {
             total_walking_duration += section.duration();
@@ -140,6 +147,7 @@ void compute_metadata(pbnavitia::Journey& pb_journey) {
     durations->set_bike(total_bike_duration);
     durations->set_car(total_car_duration);
     durations->set_ridesharing(total_ridesharing_duration);
+    durations->set_taxi(total_taxi_duration);
     durations->set_total(ts_arrival - ts_departure);
 
     auto* distances = pb_journey.mutable_distances();
@@ -147,6 +155,7 @@ void compute_metadata(pbnavitia::Journey& pb_journey) {
     distances->set_bike(total_bike_distance);
     distances->set_car(total_car_distance);
     distances->set_ridesharing(total_ridesharing_distance);
+    distances->set_taxi(total_taxi_distance);
 
     pb_journey.set_duration(ts_arrival - ts_departure);
 }

--- a/asgard/tests/direct_path_response_builder_test.cpp
+++ b/asgard/tests/direct_path_response_builder_test.cpp
@@ -139,7 +139,7 @@ void add_section(pbnavitia::Journey& pb_journey, const pbnavitia::SectionType se
 BOOST_AUTO_TEST_CASE(compute_metadata_test) {
     auto pb_journey = pbnavitia::Journey();
     pb_journey.set_departure_date_time(1470241573);
-    pb_journey.set_arrival_date_time(1470242073);
+    pb_journey.set_arrival_date_time(1470242173);
 
     add_section(pb_journey, pbnavitia::STREET_NETWORK, pbnavitia::StreetNetworkMode::Walking, 1337, 442, 1470241573);
     add_section(pb_journey, pbnavitia::STREET_NETWORK, pbnavitia::StreetNetworkMode::Car, 30, 26, 1470241673);
@@ -147,6 +147,7 @@ BOOST_AUTO_TEST_CASE(compute_metadata_test) {
     add_section(pb_journey, pbnavitia::STREET_NETWORK, pbnavitia::StreetNetworkMode::Bike, 62, 777, 1470241873);
     add_section(pb_journey, pbnavitia::STREET_NETWORK, pbnavitia::StreetNetworkMode::Bss, 999, 29, 1470241973);
     add_section(pb_journey, pbnavitia::STREET_NETWORK, pbnavitia::StreetNetworkMode::Ridesharing, 42, 78, 1470242073);
+    add_section(pb_journey, pbnavitia::STREET_NETWORK, pbnavitia::StreetNetworkMode::Taxi, 95, 200, 1470242173);
 
     compute_metadata(pb_journey);
 
@@ -157,15 +158,18 @@ BOOST_AUTO_TEST_CASE(compute_metadata_test) {
     BOOST_CHECK_EQUAL(durations.bike(), 1061);
     BOOST_CHECK_EQUAL(durations.car(), 75);
     BOOST_CHECK_EQUAL(durations.ridesharing(), 42);
+    BOOST_CHECK_EQUAL(durations.taxi(), 95);
 
     // Not the sum of all the lengths
     // arrival_last_section - departure_first_section
-    BOOST_CHECK_EQUAL(durations.total(), 542);
+    // Here (1470242173 + 95) - 1470241573
+    BOOST_CHECK_EQUAL(durations.total(), 695);
 
     BOOST_CHECK_EQUAL(distances.walking(), 442);
     BOOST_CHECK_EQUAL(distances.bike(), 806);
     BOOST_CHECK_EQUAL(distances.car(), 59);
     BOOST_CHECK_EQUAL(distances.ridesharing(), 78);
+    BOOST_CHECK_EQUAL(distances.taxi(), 200);
 }
 
 BOOST_AUTO_TEST_CASE(compute_path_items_test) {


### PR DESCRIPTION
Fix warning :
`asgard/asgard/direct_path_response_builder.cpp:111:21: warning: enumeration value 'Taxi' not handled in switch [-Wswitch]`