### PR TITLE
Fix warning

### DIFF
--- a/asgard/tests/util_test.cpp
+++ b/asgard/tests/util_test.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(convert_valhalla_to_navitia_cycle_lane_test) {
     BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kShared), pbnavitia::SharedCycleWay);
     BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kDedicated), pbnavitia::DedicatedCycleWay);
     BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(odin::TripPath_CycleLane_kSeparated), pbnavitia::SeparatedCycleWay);
-    BOOST_CHECK_NO_THROW(convert_valhalla_to_navitia_cycle_lane(static_cast<odin::TripPath::CycleLane>(42)));
+    BOOST_CHECK_EQUAL(convert_valhalla_to_navitia_cycle_lane(static_cast<odin::TripPath::CycleLane>(42)), pbnavitia::NoCycleLane);
 }
 
 } // namespace util

--- a/asgard/util.cpp
+++ b/asgard/util.cpp
@@ -66,6 +66,7 @@ pbnavitia::CyclePathType convert_valhalla_to_navitia_cycle_lane(const odin::Trip
 
     default:
         LOG_WARN("Unknown convert_valhalla_to_navitia_cycle_lane parameter. Value = " + std::to_string(cycle_lane));
+        return pbnavitia::NoCycleLane;
     }
 }
 


### PR DESCRIPTION
Fix `warning: control reaches end of non-void function [-Wreturn-type]`