### PR TITLE
Use cache only for matrix and add nb_cache_miss in metrics

### DIFF
--- a/asgard/asgard_conf.h
+++ b/asgard/asgard_conf.h
@@ -46,7 +46,7 @@ struct AsgardConf {
     AsgardConf() {
         configure_logs("ASGARD_LOGGING_FILE_PATH");
         socket_path = get_config<std::string>("ASGARD_SOCKET_PATH", "tcp://*:6000");
-        cache_size = get_config<size_t>("ASGARD_CACHE_SIZE", 100000);
+        cache_size = get_config<size_t>("ASGARD_CACHE_SIZE", 1000000);
         nb_threads = get_config<size_t>("ASGARD_NB_THREADS", 3);
         metrics_binding = get_config<std::string>("ASGARD_METRICS_BINDING", std::string("0.0.0.0:8080"));
 

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -263,7 +263,7 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
     LOG_INFO("Projecting locations done.");
 
     if (projected_locations.size() != 2) {
-        return make_error_response(pbnavitia::Error::no_origin_nor_destination, "Cannot prject the given coords!");
+        return make_error_response(pbnavitia::Error::no_origin_nor_destination, "Cannot project the given coords!");
     }
 
     Location origin;

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -263,7 +263,7 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
     LOG_INFO("Projecting locations done.");
 
     if (projected_locations.size() != 2) {
-        return make_error_response(pbnavitia::Error::no_origin_nor_destination, "Cannot project the given coords!");
+        return make_error_response(pbnavitia::Error::no_origin_nor_destination, "Cannot prject the given coords!");
     }
 
     Location origin;

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -152,31 +152,31 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
     mode_costing.update_costing_for_mode(mode, request.sn_routing_matrix().speed());
     const auto costing = mode_costing.get_costing_for_mode(mode);
 
-    LOG_INFO("Projecting " + std::to_string(navitia_sources.size() + navitia_targets.size()) + " locations...");
-    const auto range = boost::range::join(navitia_sources, navitia_targets);
-    const auto projected_locations = projector(begin(range), end(range), graph, mode, costing);
-
-    if (projected_locations.empty()) {
-        return make_error_response(pbnavitia::Error::no_origin_nor_destination, "Cannot project the given coords!");
+    // We use the cache only when there are more than one element in the sources/targets, so the cache will keep only stop_points coord
+    bool use_cache = (navitia_sources.size() != 1);
+    const auto projected_sources_locations = projector(begin(navitia_sources), end(navitia_sources), graph, mode, costing, use_cache);
+    if (projected_sources_locations.empty()) {
+        LOG_ERROR("All sources projections failed!");
+        return make_error_response(pbnavitia::Error::no_origin, "origins projection failed!");
     }
+
+    use_cache = (navitia_targets.size() != 1);
+    const auto projected_targets_locations = projector(begin(navitia_targets), end(navitia_targets), graph, mode, costing, use_cache);
+    if (projected_targets_locations.empty()) {
+        LOG_ERROR("All targets projections failed!");
+        return make_error_response(pbnavitia::Error::no_destination, "destinations projection failed!");
+    }
+
     LOG_INFO("Projecting locations done.");
 
     ValhallaLocations valhalla_location_sources;
     ProjectionFailedMask projection_mask_sources;
-    std::tie(valhalla_location_sources, projection_mask_sources) = make_valhalla_locations_from_projected_locations(navitia_sources, projected_locations, graph);
+    std::tie(valhalla_location_sources, projection_mask_sources) = make_valhalla_locations_from_projected_locations(navitia_sources, projected_sources_locations, graph);
 
     ValhallaLocations valhalla_location_targets;
     ProjectionFailedMask projection_mask_targets;
-    std::tie(valhalla_location_targets, projection_mask_targets) = make_valhalla_locations_from_projected_locations(navitia_targets, projected_locations, graph);
+    std::tie(valhalla_location_targets, projection_mask_targets) = make_valhalla_locations_from_projected_locations(navitia_targets, projected_targets_locations, graph);
 
-    if (valhalla_location_sources.empty()) {
-        LOG_ERROR("All sources projections failed!");
-        return make_error_response(pbnavitia::Error::no_origin, "origins projection failed");
-    }
-    if (valhalla_location_targets.empty()) {
-        LOG_ERROR("All targets projections failed!");
-        return make_error_response(pbnavitia::Error::no_destination, "destinations projection failed");
-    }
     LOG_INFO(std::to_string(projection_mask_sources.count()) + " origin(s) projection failed " +
              std::to_string(projection_mask_targets.count()) + " target(s) projection failed");
 
@@ -257,7 +257,9 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
                                        request.direct_path().destination().place()};
 
     LOG_INFO("Projecting locations...");
-    auto projected_locations = projector(begin(locations), end(locations), graph, mode, costing);
+    // It's a direct path.. we don't pollute the cache with random coords...
+    const bool use_cache = false;
+    auto projected_locations = projector(begin(locations), end(locations), graph, mode, costing, use_cache);
     LOG_INFO("Projecting locations done.");
 
     if (projected_locations.size() != 2) {

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -160,7 +160,7 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
         return make_error_response(pbnavitia::Error::no_origin, "origins projection failed!");
     }
 
-    use_cache = (navitia_targets.size() != 1);
+    use_cache = (navitia_targets.size() > 1);
     const auto projected_targets_locations = projector(begin(navitia_targets), end(navitia_targets), graph, mode, costing, use_cache);
     if (projected_targets_locations.empty()) {
         LOG_ERROR("All targets projections failed!");

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -153,7 +153,7 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
     const auto costing = mode_costing.get_costing_for_mode(mode);
 
     // We use the cache only when there are more than one element in the sources/targets, so the cache will keep only stop_points coord
-    bool use_cache = (navitia_sources.size() != 1);
+    bool use_cache = (navitia_sources.size() > 1);
     const auto projected_sources_locations = projector(begin(navitia_sources), end(navitia_sources), graph, mode, costing, use_cache);
     if (projected_sources_locations.empty()) {
         LOG_ERROR("All sources projections failed!");

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -229,6 +229,8 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
 
     const auto duration = pt::microsec_clock::universal_time() - start;
     metrics.observe_handle_matrix(mode, duration.total_milliseconds() / 1000.0);
+    metrics.observe_nb_cache_miss(projector.get_nb_cache_miss());
+
     return response;
 }
 

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -229,7 +229,7 @@ pbnavitia::Response Handler::handle_matrix(const pbnavitia::Request& request) {
 
     const auto duration = pt::microsec_clock::universal_time() - start;
     metrics.observe_handle_matrix(mode, duration.total_milliseconds() / 1000.0);
-    metrics.observe_nb_cache_miss(projector.get_nb_cache_miss());
+    metrics.observe_nb_cache_miss(projector.get_nb_cache_miss(), projector.get_nb_cache_calls());
 
     return response;
 }

--- a/asgard/metrics.cpp
+++ b/asgard/metrics.cpp
@@ -82,7 +82,7 @@ Metrics::Metrics(const boost::optional<const AsgardConf&>& config) {
 
     auto& in_flight_family = prometheus::BuildGauge()
                                  .Name("asgard_request_in_flight")
-                                 .Help("Number of requests currently beeing processed")
+                                 .Help("Number of requests currently being processed")
                                  .Register(*registry);
     this->in_flight = &in_flight_family.Add({});
 
@@ -103,6 +103,13 @@ Metrics::Metrics(const boost::optional<const AsgardConf&>& config) {
         auto& histo_matrix = matrix_family.Add({{"mode", mode}}, create_fixed_duration_buckets());
         this->handle_matrix_histogram[mode] = &histo_matrix;
     }
+
+    auto& nb_cache_miss = prometheus::BuildGauge()
+                              .Name("nb_cache_miss")
+                              .Help("Nbr of projector's cache miss from the start of app")
+                              .Register(*registry);
+
+    nb_cache_miss_gauge = &nb_cache_miss.Add({});
 }
 
 InFlightGuard Metrics::start_in_flight() const {
@@ -134,6 +141,13 @@ void Metrics::observe_handle_matrix(const std::string& mode, double duration) co
     } else {
         LOG_WARN("mode " + mode + " not found in metrics");
     }
+}
+
+void Metrics::observe_nb_cache_miss(uint64_t nb_cache_miss) const {
+    if (!registry) {
+        return;
+    }
+    nb_cache_miss_gauge->Set(nb_cache_miss);
 }
 
 } // namespace asgard

--- a/asgard/metrics.cpp
+++ b/asgard/metrics.cpp
@@ -104,12 +104,17 @@ Metrics::Metrics(const boost::optional<const AsgardConf&>& config) {
         this->handle_matrix_histogram[mode] = &histo_matrix;
     }
 
-    auto& nb_cache_miss = prometheus::BuildGauge()
-                              .Name("nb_cache_miss")
-                              .Help("Nbr of projector's cache miss from the start of app")
-                              .Register(*registry);
+    nb_cache_miss_gauge = &prometheus::BuildGauge()
+                               .Name("nb_cache_miss")
+                               .Help("Nb of projector's cache miss from the start of app")
+                               .Register(*registry)
+                               .Add({});
 
-    nb_cache_miss_gauge = &nb_cache_miss.Add({});
+    nb_cache_call_gauge = &prometheus::BuildGauge()
+                               .Name("nb_cache_calls")
+                               .Help("Nb of projector's cache calls from the start of app")
+                               .Register(*registry)
+                               .Add({});
 }
 
 InFlightGuard Metrics::start_in_flight() const {
@@ -143,11 +148,12 @@ void Metrics::observe_handle_matrix(const std::string& mode, double duration) co
     }
 }
 
-void Metrics::observe_nb_cache_miss(uint64_t nb_cache_miss) const {
+void Metrics::observe_nb_cache_miss(uint64_t nb_cache_miss, uint64_t nb_cache_calls) const {
     if (!registry) {
         return;
     }
     nb_cache_miss_gauge->Set(nb_cache_miss);
+    nb_cache_call_gauge->Set(nb_cache_calls);
 }
 
 } // namespace asgard

--- a/asgard/metrics.h
+++ b/asgard/metrics.h
@@ -39,6 +39,7 @@ protected:
     std::map<const std::string, prometheus::Histogram*> handle_direct_path_histogram;
     std::map<const std::string, prometheus::Histogram*> handle_matrix_histogram;
     prometheus::Gauge* nb_cache_miss_gauge;
+    prometheus::Gauge* nb_cache_call_gauge;
 
 public:
     explicit Metrics(const boost::optional<const AsgardConf&>& config);
@@ -46,7 +47,7 @@ public:
 
     void observe_handle_direct_path(const std::string&, double duration) const;
     void observe_handle_matrix(const std::string&, double duration) const;
-    void observe_nb_cache_miss(uint64_t nb_cache_miss) const;
+    void observe_nb_cache_miss(uint64_t nb_cache_miss, uint64_t nb_cache_calls) const;
 };
 
 } // namespace asgard

--- a/asgard/metrics.h
+++ b/asgard/metrics.h
@@ -38,6 +38,7 @@ protected:
     prometheus::Gauge* status_family;
     std::map<const std::string, prometheus::Histogram*> handle_direct_path_histogram;
     std::map<const std::string, prometheus::Histogram*> handle_matrix_histogram;
+    prometheus::Gauge* nb_cache_miss_gauge;
 
 public:
     explicit Metrics(const boost::optional<const AsgardConf&>& config);
@@ -45,6 +46,7 @@ public:
 
     void observe_handle_direct_path(const std::string&, double duration) const;
     void observe_handle_matrix(const std::string&, double duration) const;
+    void observe_nb_cache_miss(uint64_t nb_cache_miss) const;
 };
 
 } // namespace asgard

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -126,9 +126,8 @@ private:
                           const std::string& mode,
                           const valhalla::sif::cost_ptr_t& costing) const {
         std::vector<valhalla::baldr::Location> locations;
-        for (auto it = places_begin; it != places_end; ++it) {
-            locations.push_back(build_location(*it, reachability, radius));
-        }
+        std::transform(places_begin, places_end, std::back_inserter(locations), 
+              bind(build_location, placeholders::_1, reachability, radius));
         std::unordered_map<std::string, valhalla::baldr::PathLocation> results;
         const auto path_locations = valhalla::loki::Search(locations,
                                                            graph,

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -127,7 +127,7 @@ private:
                           const valhalla::sif::cost_ptr_t& costing) const {
         std::vector<valhalla::baldr::Location> locations;
         for (auto it = places_begin; it != places_end; ++it) {
-            ²locations.push_back(build_location(*it, reachability, radius));
+            locations.push_back(build_location(*it, reachability, radius));
         }
         std::unordered_map<std::string, valhalla::baldr::PathLocation> results;
         const auto path_locations = valhalla::loki::Search(locations,

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -36,7 +36,7 @@ private:
     // exterior because of the purity of f
     mutable Cache cache;
     mutable size_t nb_cache_miss = 0;
-    mutable size_t nb_calls = 0;
+    mutable size_t nb_cache_calls = 0;
     mutable std::mutex mutex;
 
     valhalla::baldr::Location build_location(const std::string& place,
@@ -73,7 +73,7 @@ public:
     }
 
     size_t get_nb_cache_miss() const { return nb_cache_miss; }
-    size_t get_nb_calls() const { return nb_calls; }
+    size_t get_nb_cache_calls() const { return nb_cache_calls; }
 
 private:
     template<typename T>
@@ -90,7 +90,7 @@ private:
         {
             std::lock_guard<std::mutex> lock(mutex);
             for (auto it = places_begin; it != places_end; ++it) {
-                ++nb_calls;
+                ++nb_cache_calls;
                 const auto search = map.find(std::make_pair(*it, mode));
                 if (search != map.end()) {
                     // put the cached value at the begining of the cache

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -125,10 +125,12 @@ private:
                           valhalla::baldr::GraphReader& graph,
                           const std::string& mode,
                           const valhalla::sif::cost_ptr_t& costing) const {
-        std::vector<valhalla::baldr::Location> missed;
+        std::vector<valhalla::baldr::Location> locations;
+        for (auto it = places_begin; it != places_end; ++it) {
+            ²locations.push_back(build_location(*it, reachability, radius));
+        }
         std::unordered_map<std::string, valhalla::baldr::PathLocation> results;
-
-        const auto path_locations = valhalla::loki::Search(missed,
+        const auto path_locations = valhalla::loki::Search(locations,
                                                            graph,
                                                            costing->GetEdgeFilter(),
                                                            costing->GetNodeFilter());

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -126,13 +126,16 @@ private:
                           const std::string& mode,
                           const valhalla::sif::cost_ptr_t& costing) const {
         std::vector<valhalla::baldr::Location> locations;
-        std::transform(places_begin, places_end, std::back_inserter(locations), 
-              bind(build_location, placeholders::_1, reachability, radius));
-        std::unordered_map<std::string, valhalla::baldr::PathLocation> results;
+        std::transform(places_begin, places_end, std::back_inserter(locations),
+                       [this](const std::string& place) {
+                           return build_location(place, reachability, radius);
+                       });
         const auto path_locations = valhalla::loki::Search(locations,
                                                            graph,
                                                            costing->GetEdgeFilter(),
                                                            costing->GetNodeFilter());
+
+        std::unordered_map<std::string, valhalla::baldr::PathLocation> results;
         for (const auto& l : path_locations) {
             results.emplace(l.first.name_, l.second);
         }

--- a/asgard/projector.h
+++ b/asgard/projector.h
@@ -65,11 +65,11 @@ public:
                valhalla::baldr::GraphReader& graph,
                const std::string& mode,
                const valhalla::sif::cost_ptr_t& costing,
-	       const bool use_cache = true) const {
-               if(use_cache){
-                   return project_with_cache(places_begin, places_end, graph, mode, costing);
-               }
-               return project_without_cache(places_begin, places_end, graph, mode, costing);
+               const bool use_cache = true) const {
+        if (use_cache) {
+            return project_with_cache(places_begin, places_end, graph, mode, costing);
+        }
+        return project_without_cache(places_begin, places_end, graph, mode, costing);
     }
 
     size_t get_nb_cache_miss() const { return nb_cache_miss; }
@@ -79,10 +79,10 @@ private:
     template<typename T>
     std::unordered_map<std::string, valhalla::baldr::PathLocation>
     project_with_cache(const T places_begin,
-            const T places_end,
-            valhalla::baldr::GraphReader& graph,
-            const std::string& mode,
-            const valhalla::sif::cost_ptr_t& costing) const {
+                       const T places_end,
+                       valhalla::baldr::GraphReader& graph,
+                       const std::string& mode,
+                       const valhalla::sif::cost_ptr_t& costing) const {
         std::unordered_map<std::string, valhalla::baldr::PathLocation> results;
         std::vector<valhalla::baldr::Location> missed;
         auto& list = cache.template get<0>();
@@ -121,22 +121,22 @@ private:
     template<typename T>
     std::unordered_map<std::string, valhalla::baldr::PathLocation>
     project_without_cache(const T places_begin,
-            const T places_end,
-            valhalla::baldr::GraphReader& graph,
-            const std::string& mode,
-            const valhalla::sif::cost_ptr_t& costing)const{
-            std::vector<valhalla::baldr::Location> missed;
-            std::unordered_map<std::string, valhalla::baldr::PathLocation> results;
+                          const T places_end,
+                          valhalla::baldr::GraphReader& graph,
+                          const std::string& mode,
+                          const valhalla::sif::cost_ptr_t& costing) const {
+        std::vector<valhalla::baldr::Location> missed;
+        std::unordered_map<std::string, valhalla::baldr::PathLocation> results;
 
-            const auto path_locations = valhalla::loki::Search(missed,
-                                                               graph,
-                                                               costing->GetEdgeFilter(),
-                                                               costing->GetNodeFilter());
-            for (const auto& l : path_locations) {
-                results.emplace(l.first.name_, l.second);
-            }
-            return results;
+        const auto path_locations = valhalla::loki::Search(missed,
+                                                           graph,
+                                                           costing->GetEdgeFilter(),
+                                                           costing->GetNodeFilter());
+        for (const auto& l : path_locations) {
+            results.emplace(l.first.name_, l.second);
         }
+        return results;
+    }
 };
 
 } // namespace asgard

--- a/asgard/tests/projector_test.cpp
+++ b/asgard/tests/projector_test.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(simple_projector_test) {
         auto result = p(begin(locations), end(locations), graph, "car", costing);
         BOOST_CHECK_EQUAL(result.size(), 0);
         BOOST_CHECK_EQUAL(p.get_nb_cache_miss(), 1);
-        BOOST_CHECK_EQUAL(p.get_nb_calls(), 1);
+        BOOST_CHECK_EQUAL(p.get_nb_cache_calls(), 1);
     }
     // cache = {}
     {
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(simple_projector_test) {
         auto result = p(begin(locations), end(locations), graph, "car", costing);
         BOOST_CHECK_EQUAL(result.size(), 1);
         BOOST_CHECK_EQUAL(p.get_nb_cache_miss(), 2);
-        BOOST_CHECK_EQUAL(p.get_nb_calls(), 2);
+        BOOST_CHECK_EQUAL(p.get_nb_cache_calls(), 2);
     }
     // cache = { coord:.03:.01 }
     {
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(simple_projector_test) {
         auto result = p(begin(locations), end(locations), graph, "car", costing);
         BOOST_CHECK_EQUAL(result.size(), 1);
         BOOST_CHECK_EQUAL(p.get_nb_cache_miss(), 2);
-        BOOST_CHECK_EQUAL(p.get_nb_calls(), 3);
+        BOOST_CHECK_EQUAL(p.get_nb_cache_calls(), 3);
     }
     // cache = { coord:.03:.01 }
     {
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(simple_projector_test) {
         auto result = p(begin(locations), end(locations), graph, "car", costing);
         BOOST_CHECK_EQUAL(result.size(), 1);
         BOOST_CHECK_EQUAL(p.get_nb_cache_miss(), 3);
-        BOOST_CHECK_EQUAL(p.get_nb_calls(), 4);
+        BOOST_CHECK_EQUAL(p.get_nb_cache_calls(), 4);
     }
     // cache = { coord:.09:.01; coord:.03:.01 }
     {
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(simple_projector_test) {
         auto result = p(begin(locations), end(locations), graph, "car", costing);
         BOOST_CHECK_EQUAL(result.size(), 1);
         BOOST_CHECK_EQUAL(p.get_nb_cache_miss(), 3);
-        BOOST_CHECK_EQUAL(p.get_nb_calls(), 5);
+        BOOST_CHECK_EQUAL(p.get_nb_cache_calls(), 5);
     }
     // cache = { coord:.03:.01; coord:.09:.01 }
     {
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(simple_projector_test) {
         auto result = p(begin(locations), end(locations), graph, "car", costing);
         BOOST_CHECK_EQUAL(result.size(), 1);
         BOOST_CHECK_EQUAL(p.get_nb_cache_miss(), 4);
-        BOOST_CHECK_EQUAL(p.get_nb_calls(), 6);
+        BOOST_CHECK_EQUAL(p.get_nb_cache_calls(), 6);
     }
     // cache = { coord:.13:.01; coord:.03:.01 }
     {
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(simple_projector_test) {
         auto result = p(begin(locations), end(locations), graph, "car", costing);
         BOOST_CHECK_EQUAL(result.size(), 1);
         BOOST_CHECK_EQUAL(p.get_nb_cache_miss(), 5);
-        BOOST_CHECK_EQUAL(p.get_nb_calls(), 7);
+        BOOST_CHECK_EQUAL(p.get_nb_cache_calls(), 7);
     }
     // cache = { coord:.09:.01; coord:.13:.01 }
 }

--- a/docker/asgard-data/Dockerfile
+++ b/docker/asgard-data/Dockerfile
@@ -13,8 +13,8 @@ RUN wget --progress=bar:force:noscroll $pbf_url \
   # These are default values set after empirically testing asgard with distributed.
   # They seem to give the most coherent results between the time of the matrix and the direct_path
   # And fixing some projection problems in dead-ends or isolated places.
-  && sed -i 's,\"minimum_reachability\"\: [[:digit:]]*,\"minimum_reachability\"\: 0,' valhalla.json \
-  && sed -i 's,\"radius\"\: [[:digit:]]*,\"radius\"\: 30,' valhalla.json \
+  && sed -i 's,\"minimum_reachability\"\: [[:digit:]]*,\"minimum_reachability\"\: 30,' valhalla.json \
+  && sed -i 's,\"radius\"\: [[:digit:]]*,\"radius\"\: 0,' valhalla.json \
   && sed -i 's,\"shortcuts\"\: [^,]*,\"shortcuts\"\: false,' valhalla.json \
   && sed -i 's,\"hierarchy\"\: [^,]*,\"hierarchy\"\: false,' valhalla.json \
   && valhalla_build_elevation $elevation_min_x_max_x_min_y_max_y ${PWD}/elevation_tiles $(nproc) \


### PR DESCRIPTION
- The projector's cache is only used for matrix, so the cache is changed much less. The direct path's projection is done on fly.

- With the PR, the `nb_cache_miss` and `nb_cache_calls` are also exposed to metrics. The ratio of `nb_cache_miss/nb_cache_calls` may be correlated with the performance of Asgard later.

I also change the size of the projection cache. I tested 10K requests on STIF：
- With a cache of 100K items: the average nb_cache_miss per request is 1.5
- With a cache of 1M items: the average nb_cache_miss per request is 0.4 