### PR TITLE
use float as coord

### DIFF
--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -69,8 +69,8 @@ pbnavitia::Response build_journey_response(const pbnavitia::Request& request,
     set_extremity_pt_object(list_geo_points.front(), s->mutable_origin());
     set_extremity_pt_object(list_geo_points.back(), s->mutable_destination());
     compute_geojson(list_geo_points, *s);
-    bool enable_instructoin = request.direct_path().streetnetwork_params().enable_instructions();
-    compute_path_items(api, s->mutable_street_network(), enable_instructoin);
+    bool enable_instructions = request.direct_path().streetnetwork_params().enable_instructions();
+    compute_path_items(api, s->mutable_street_network(), enable_instructions);
 
     compute_metadata(*journey);
 
@@ -175,16 +175,16 @@ void compute_path_items(valhalla::Api& api, pbnavitia::StreetNetwork* sn, const 
             set_path_item_duration(maneuver, *path_item);
             set_path_item_direction(maneuver, *path_item);
             if (enable_instruction) {
-                set_path_item_instruction(maneuver, *path_item, i == (directions_leg.maneuver_size() - 1));
+                set_path_item_instruction(maneuver, *path_item, i, directions_leg.maneuver_size());
             }
         }
     }
 }
 
-void set_path_item_instruction(const DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item, const bool is_last_item) {
+void set_path_item_instruction(const DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item, const size_t index, const size_t size) {
     if (maneuver.has_text_instruction() && !maneuver.text_instruction().empty()) {
         auto instruction = maneuver.text_instruction();
-        if (!is_last_item) {
+        if (index != (size - 1)) {
             instruction += " Keep going for " + std::to_string((int)(maneuver.length() * KM_TO_M)) + " m.";
         }
         path_item.set_instruction(instruction);

--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -69,7 +69,8 @@ pbnavitia::Response build_journey_response(const pbnavitia::Request& request,
     set_extremity_pt_object(list_geo_points.front(), s->mutable_origin());
     set_extremity_pt_object(list_geo_points.back(), s->mutable_destination());
     compute_geojson(list_geo_points, *s);
-    compute_path_items(api, s->mutable_street_network());
+    bool enable_instructoin = request.direct_path().streetnetwork_params().enable_instructions();
+    compute_path_items(api, s->mutable_street_network(), enable_instructoin);
 
     compute_metadata(*journey);
 
@@ -160,7 +161,7 @@ void compute_metadata(pbnavitia::Journey& pb_journey) {
     pb_journey.set_duration(ts_arrival - ts_departure);
 }
 
-void compute_path_items(valhalla::Api& api, pbnavitia::StreetNetwork* sn) {
+void compute_path_items(valhalla::Api& api, pbnavitia::StreetNetwork* sn, const bool enable_instruction) {
     if (api.mutable_trip()->routes_size() > 0 && api.has_directions() && api.mutable_directions()->mutable_routes(0)->legs_size() > 0) {
         auto& trip_route = *api.mutable_trip()->mutable_routes(0);
         auto& directions_leg = *api.mutable_directions()->mutable_routes(0)->mutable_legs(0);
@@ -173,14 +174,20 @@ void compute_path_items(valhalla::Api& api, pbnavitia::StreetNetwork* sn) {
             set_path_item_length(maneuver, *path_item);
             set_path_item_duration(maneuver, *path_item);
             set_path_item_direction(maneuver, *path_item);
-            set_path_item_instruction(maneuver, *path_item);
+            if (enable_instruction) {
+                set_path_item_instruction(maneuver, *path_item, i == (directions_leg.maneuver_size() - 1));
+            }
         }
     }
 }
 
-void set_path_item_instruction(const DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item) {
+void set_path_item_instruction(const DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item, const bool is_last_item) {
     if (maneuver.has_text_instruction() && !maneuver.text_instruction().empty()) {
-        path_item.set_instruction(maneuver.text_instruction() + " Continuez pendant " + std::to_string((int)(maneuver.length() * KM_TO_M)) + " m.");
+        auto instruction = maneuver.text_instruction();
+        if (!is_last_item) {
+            instruction += " Keep going for " + std::to_string((int)(maneuver.length() * KM_TO_M)) + " m.";
+        }
+        path_item.set_instruction(instruction);
     }
 }
 

--- a/asgard/direct_path_response_builder.h
+++ b/asgard/direct_path_response_builder.h
@@ -42,7 +42,7 @@ void set_path_item_length(const valhalla::DirectionsLeg_Maneuver& maneuver, pbna
 void set_path_item_type(const valhalla::TripLeg_Edge& edge, pbnavitia::PathItem& path_item);
 void set_path_item_duration(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
 void set_path_item_direction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
-void set_path_item_instruction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item, const bool is_last_item);
+void set_path_item_instruction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item, const size_t index, const size_t size);
 
 } // namespace direct_path_response_builder
 } // namespace asgard

--- a/asgard/direct_path_response_builder.h
+++ b/asgard/direct_path_response_builder.h
@@ -35,14 +35,14 @@ pbnavitia::Response build_journey_response(const pbnavitia::Request& request,
 void set_extremity_pt_object(const valhalla::midgard::PointLL& geo_point, pbnavitia::PtObject* o);
 void compute_metadata(pbnavitia::Journey& pb_journey);
 void compute_geojson(const std::vector<valhalla::midgard::PointLL>& list_geo_points, pbnavitia::Section& s);
-void compute_path_items(valhalla::Api& api, pbnavitia::StreetNetwork* sn);
+void compute_path_items(valhalla::Api& api, pbnavitia::StreetNetwork* sn, const bool enable_instruction);
 
 void set_path_item_name(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
 void set_path_item_length(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
 void set_path_item_type(const valhalla::TripLeg_Edge& edge, pbnavitia::PathItem& path_item);
 void set_path_item_duration(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
 void set_path_item_direction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
-void set_path_item_instruction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
+void set_path_item_instruction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item, const bool is_last_item);
 
 } // namespace direct_path_response_builder
 } // namespace asgard

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -28,7 +28,6 @@
 #include <valhalla/thor/attributes_controller.h>
 #include <valhalla/thor/triplegbuilder.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/join.hpp>
 
 #include <ctime>

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -15,6 +15,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "asgard/handler.h"
+#include "utils/coord_parser.h"
 #include "asgard/context.h"
 #include "asgard/direct_path_response_builder.h"
 #include "asgard/metrics.h"
@@ -22,11 +23,12 @@
 #include "asgard/request.pb.h"
 #include "asgard/util.h"
 
+#include <valhalla/midgard/pointll.h>
 #include <valhalla/odin/directionsbuilder.h>
 #include <valhalla/thor/attributes_controller.h>
 #include <valhalla/thor/triplegbuilder.h>
-
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/join.hpp>
 
 #include <ctime>
@@ -38,7 +40,7 @@ using namespace valhalla;
 namespace asgard {
 
 using ValhallaLocations = google::protobuf::RepeatedPtrField<valhalla::Location>;
-using ProjectedLocations = std::unordered_map<std::string, valhalla::baldr::PathLocation>;
+using ProjectedLocations = std::unordered_map<midgard::PointLL, valhalla::baldr::PathLocation>;
 
 // The max size of matrix in jormungandr is 5000 so far...
 constexpr size_t MAX_MASK_SIZE = 10000;
@@ -85,19 +87,24 @@ double get_speed_request(const pbnavitia::Request& request, const std::string& m
 }
 
 using LocationContextList = google::protobuf::RepeatedPtrField<pbnavitia::LocationContext>;
-std::vector<std::string> get_locations_from_matrix_request(const LocationContextList& request_locations) {
-    std::vector<std::string> locations;
+
+std::vector<midgard::PointLL> get_locations_from_matrix_request(const LocationContextList& request_locations) {
+    std::vector<midgard::PointLL> locations;
     locations.reserve(request_locations.size());
 
     for (const auto& l : request_locations) {
-        locations.push_back(l.place());
+        if (l.has_lat() && l.has_lon()) {
+            locations.emplace_back(l.lon(), l.lat());
+        } else {
+            locations.push_back(navitia::parse_coordinate(l.place()));
+        }
     }
 
     return locations;
 }
 
 std::pair<ValhallaLocations, ProjectionFailedMask>
-make_valhalla_locations_from_projected_locations(const std::vector<std::string>& navitia_locations,
+make_valhalla_locations_from_projected_locations(const std::vector<midgard::PointLL>& navitia_locations,
                                                  const ProjectedLocations& projected_locations,
                                                  valhalla::baldr::GraphReader& graph) {
     ValhallaLocations valhalla_locations;
@@ -111,7 +118,7 @@ make_valhalla_locations_from_projected_locations(const std::vector<std::string>&
         auto it = projected_locations.find(l);
         if (it == projected_locations.end()) {
             projection_failed_mask.set(source_idx);
-            LOG_ERROR("Cannot project coor: " + l);
+            LOG_ERROR("Cannot project coord: " + std::to_string(l.lng()) + ";" + std::to_string(l.lat()));
             continue;
         }
         baldr::PathLocation::toPBF(it->second, valhalla_locations.Add(), graph);
@@ -123,7 +130,6 @@ make_valhalla_locations_from_projected_locations(const std::vector<std::string>&
 } // namespace
 
 Handler::Handler(const Context& context) : graph(context.graph),
-
                                            metrics(context.metrics),
                                            projector(context.projector) {
 }
@@ -254,8 +260,14 @@ pbnavitia::Response Handler::handle_direct_path(const pbnavitia::Request& reques
     mode_costing.update_costing_for_mode(mode, speed_request);
     auto costing = mode_costing.get_costing_for_mode(mode);
 
-    std::vector<std::string> locations{request.direct_path().origin().place(),
-                                       request.direct_path().destination().place()};
+    std::vector<midgard::PointLL> locations;
+    boost::for_each(std::vector<pbnavitia::LocationContext>{request.direct_path().origin(), request.direct_path().destination()},
+                    [&locations](const auto l) {
+    	            	 if(l.has_lat() && l.has_lon()) {
+    	            		 locations.emplace_back(l.lon(), l.lat());
+    	            	 } else {
+    	            		 locations.emplace_back(navitia::parse_coordinate(l.place()));
+    	            	 } });
 
     LOG_INFO("Projecting locations...");
     // It's a direct path.. we don't pollute the cache with random coords...

--- a/asgard/tests/benchmark_projector_cache.cpp
+++ b/asgard/tests/benchmark_projector_cache.cpp
@@ -4,20 +4,22 @@
 #include "utils/timer.h"
 
 #include <valhalla/baldr/graphreader.h>
+#include <valhalla/midgard/pointll.h>
 
 #include <boost/program_options.hpp>
 #include <boost/progress.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <algorithm>
 #include <random>
 #include <thread>
 
 namespace po = boost::program_options;
 using namespace valhalla::baldr;
 using namespace asgard;
-using ListOfLocations = std::vector<std::vector<std::string>>;
-using ListOfResults = std::vector<std::unordered_map<std::string, PathLocation>>;
+using ListOfLocations = std::vector<std::vector<valhalla::midgard::PointLL>>;
+using ListOfResults = std::vector<std::unordered_map<valhalla::midgard::PointLL, PathLocation>>;
 
 void compute(const Projector& projector, boost::property_tree::ptree conf, boost::progress_display& show_progress, ListOfLocations list_of_locations) {
 
@@ -534,8 +536,14 @@ ListOfLocations build_list_of_locations(size_t nb_threads) {
                                           "coord:2.292557:48.825697",
                                           "coord:2.284232:48.793203",
                                           "coord:2.304749:48.811078"};
+
+    std::vector<valhalla::midgard::PointLL> pointLLs;
+    std::transform(locations.begin(), locations.end(), std::back_inserter(pointLLs), [](const auto& coord) {
+        return valhalla::midgard::PointLL{navitia::parse_coordinate(coord)};
+    });
+
     for (size_t i = 0; i < list_size; ++i) {
-        list_of_locations.push_back(locations);
+        list_of_locations.push_back(pointLLs);
     }
 
     std::cout << "nb of locations = " << (list_of_locations.size() * locations.size()) * nb_threads << std::endl;

--- a/asgard/tests/benchmark_projector_cache.cpp
+++ b/asgard/tests/benchmark_projector_cache.cpp
@@ -10,6 +10,7 @@
 #include <boost/progress.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <boost/range/algorithm/transform.hpp>
 
 #include <algorithm>
 #include <random>
@@ -538,7 +539,7 @@ ListOfLocations build_list_of_locations(size_t nb_threads) {
                                           "coord:2.304749:48.811078"};
 
     std::vector<valhalla::midgard::PointLL> pointLLs;
-    std::transform(locations.begin(), locations.end(), std::back_inserter(pointLLs), [](const auto& coord) {
+    boost::transform(locations, std::back_inserter(pointLLs), [](const auto& coord) {
         return valhalla::midgard::PointLL{navitia::parse_coordinate(coord)};
     });
 

--- a/asgard/tests/direct_path_response_builder_test.cpp
+++ b/asgard/tests/direct_path_response_builder_test.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(compute_path_items_test) {
         Api api;
         auto sn = pbnavitia::StreetNetwork();
 
-        compute_path_items(api, &sn);
+        compute_path_items(api, &sn, true);
 
         BOOST_CHECK_EQUAL(sn.path_items_size(), 0);
     }

--- a/asgard/util.h
+++ b/asgard/util.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include "utils/coord_parser.h"
 #include "asgard/response.pb.h"
 
+#include <valhalla/midgard/pointll.h>
 #include <valhalla/proto/options.pb.h>
 #include <valhalla/proto/trip.pb.h>
+
+#include <boost/range/algorithm/transform.hpp>
 
 namespace valhalla {
 namespace sif {
@@ -24,6 +28,24 @@ size_t navitia_to_valhalla_mode_index(const std::string& mode);
 valhalla::Costing convert_navitia_to_valhalla_costing(const std::string& costing);
 
 pbnavitia::CyclePathType convert_valhalla_to_navitia_cycle_lane(const valhalla::TripLeg_CycleLane& cycle_lane);
+
+template<typename SingleRange>
+std::vector<valhalla::midgard::PointLL> convert_locations_to_pointLL(const SingleRange& request_locations) {
+    std::vector<valhalla::midgard::PointLL> points;
+    points.reserve(request_locations.size());
+
+    boost::transform(request_locations, std::back_inserter(points),
+                     [](const auto& l) {
+                         if (l.has_lat() && l.has_lon()) {
+                             return valhalla::midgard::PointLL{l.lon(), l.lat()};
+                         } else {
+                             return valhalla::midgard::PointLL{navitia::parse_coordinate(l.place())};
+                         }
+                     });
+
+    return points;
+}
+
 } // namespace util
 
 } // namespace asgard


### PR DESCRIPTION
In the current version, the coordinates are passed in string format, which causes a considerable utilization of the network that we discovered during the last benchmark (https://github.com/CanalTP/navitia-proto/pull/150/files#diff-8eaed4801c3a90592de7702da587b9085703592d6f0f8cd123efbac3bea02aa0R593)

the solution is to use float to represent coordinates (https://github.com/CanalTP/navitia-proto/pull/150/files#diff-8eaed4801c3a90592de7702da587b9085703592d6f0f8cd123efbac3bea02aa0R595) and use `valhalla::migard::PointLL` in the computation.

The good news is that the `PointLL` is already hashable(https://github.com/valhalla/valhalla/blob/master/valhalla/midgard/pointll.h#L272). So we have nothing to do to keep the cache functional. 

Note that  in order to not break Prod, in this version we still support the coordinates in string format, once the next Navitia is brought to production, A new PR will be submitted to remove that support 
