### PR TITLE
fix jenkinsfile build app image

### DIFF
--- a/JenkinsfileBuildAppImage
+++ b/JenkinsfileBuildAppImage
@@ -9,6 +9,7 @@ pipeline {
                 }
             }
             steps {
+                sh "git fetch --tags"
                 sh "make build-app-image-${env.BRANCH_NAME} TAG=`make get-app-${env.BRANCH_NAME}-tag`"
             }
         }
@@ -17,6 +18,15 @@ pipeline {
                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'kisio-docker-token', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
                     sh "make dockerhub-login DOCKERHUB_USER=${USERNAME} DOCKERHUB_PWD=${PASSWORD}"
                 }
+            }
+        }
+        stage('Tag release as latest and push it') {
+            when {
+                branch 'release'
+            }
+            steps {
+                sh "docker tag navitia/asgard-app:`make get-app-${env.BRANCH_NAME}-tag` navitia/asgard-app:latest"
+                sh "docker push navitia/asgard-app:latest"
             }
         }
         stage('Push Asgard App Image') {


### PR DESCRIPTION
A little fix on jenkins file: do `git fetch --tags` before `git describe`

Tag the released image as `latest` and push `latest` only when it's on `release`