### PR TITLE
fix bss maneuver

### DIFF
--- a/asgard/mode_costing.cpp
+++ b/asgard/mode_costing.cpp
@@ -33,12 +33,12 @@ Options make_costing_option(const ModeCostingArgs& args) {
     options.mutable_costing_options(vc::pedestrian)->set_walking_speed(args.speeds[vc::pedestrian] * 3.6);
 
     // rent cost
-    options.mutable_costing_options(vc::pedestrian)->set_bike_share_cost(args.bss_rent_duration);
-    options.mutable_costing_options(vc::pedestrian)->set_bike_share_penalty(args.bss_rent_penalty);
+    options.mutable_costing_options(vc::pedestrian)->set_bike_share_cost(args.bss_return_duration);
+    options.mutable_costing_options(vc::pedestrian)->set_bike_share_penalty(args.bss_return_penalty);
 
     // return cost
-    options.mutable_costing_options(vc::bicycle)->set_bike_share_cost(args.bss_return_duration);
-    options.mutable_costing_options(vc::bicycle)->set_bike_share_penalty(args.bss_return_penalty);
+    options.mutable_costing_options(vc::bicycle)->set_bike_share_cost(args.bss_rent_duration);
+    options.mutable_costing_options(vc::bicycle)->set_bike_share_penalty(args.bss_rent_penalty);
 
     return options;
 }

--- a/asgard/util.cpp
+++ b/asgard/util.cpp
@@ -64,7 +64,7 @@ const std::map<std::string, pbnavitia::StreetNetworkMode> make_navitia_to_street
         {"taxi", pbnavitia::StreetNetworkMode::Taxi},
         {"bss", pbnavitia::StreetNetworkMode::Bss},
     };
-};
+}
 
 pbnavitia::StreetNetworkMode convert_navitia_to_streetnetwork_mode(const std::string& mode) {
     static const auto navitia_to_valhalla_mode_map = make_navitia_to_streetnetwork_mode(mode);


### PR DESCRIPTION
fix bss maneuver cost

In the pevious PR,  `bss_rent_duration` and `bss_return_duration` were not set correctly...

A test is added...

