### PR TITLE
add matrix_cost_factor

### DIFF
--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -46,7 +46,7 @@ constexpr size_t MAX_MASK_SIZE = 10000;
 using ProjectionFailedMask = std::bitset<MAX_MASK_SIZE>;
 
 constexpr float WALKING_MAX_MATRIX_COST_FACTOR = 1.;
-constexpr float BIKE_MAX_MATRIX_COST_FACTOR = 1.8;
+constexpr float BIKE_MAX_MATRIX_COST_FACTOR = 2;
 constexpr float CAR_MAX_MATRIX_COST_FACTOR = 2;
 
 namespace {

--- a/asgard/handler.cpp
+++ b/asgard/handler.cpp
@@ -45,6 +45,10 @@ using ProjectedLocations = std::unordered_map<midgard::PointLL, valhalla::baldr:
 constexpr size_t MAX_MASK_SIZE = 10000;
 using ProjectionFailedMask = std::bitset<MAX_MASK_SIZE>;
 
+constexpr float WALKING_MAX_MATRIX_COST_FACTOR = 1.;
+constexpr float BIKE_MAX_MATRIX_COST_FACTOR = 1.8;
+constexpr float CAR_MAX_MATRIX_COST_FACTOR = 2;
+
 namespace {
 
 pbnavitia::Response make_error_response(pbnavitia::Error_error_id err_id, const std::string& err_msg) {
@@ -59,12 +63,12 @@ pbnavitia::Response make_error_response(pbnavitia::Error_error_id err_id, const 
 float get_distance(const std::string& mode, float duration) {
     using namespace thor;
     if (mode == "walking") {
-        return duration * kTimeDistCostThresholdPedestrianDivisor;
+        return duration * kTimeDistCostThresholdPedestrianDivisor * WALKING_MAX_MATRIX_COST_FACTOR;
     }
     if (mode == "bike" || mode == "bss") {
-        return duration * kTimeDistCostThresholdBicycleDivisor;
+        return duration * kTimeDistCostThresholdBicycleDivisor * BIKE_MAX_MATRIX_COST_FACTOR;
     }
-    return duration * kTimeDistCostThresholdAutoDivisor;
+    return duration * kTimeDistCostThresholdAutoDivisor * CAR_MAX_MATRIX_COST_FACTOR;
 }
 
 ModeCostingArgs


### PR DESCRIPTION
**What was wrong??**
A user asked Navitia to compute a journey with `max_duration_to_pt=1200`, finally, no journey's fallback_duration surpasses 800 seconds...  The user had to increase `max_duration_to_pt` to `2200` to have a journey whose fallback last 1200 seconds...

The problem stems from the matrix in Asgard/Valhalla. The limit of the matrix (or `TimeDistanceMatrix` in Valhalla) was logically set to `max_duration` which is sent by Jormungandr. However, the value is interpreted by Valhalla as an `effort` but not `time`, which means, in addition to `time`, the value also includes the other kind of **cost** (ex. an ascending slope, unpaved road...). With that said, the value `1200` passed to Valhalla actually means `cost + time`, which largely reduces the reachable points of the requested matrix.

The solution is simple, we define empirically a factor for each mode, in order to push off `TimeDistanceMatrix`'s computation limit. 
 