### PR TITLE
Add instruction start coordinate

### DIFF
--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -536,11 +536,11 @@ void set_path_item_instruction(const DirectionsLeg_Maneuver& maneuver, pbnavitia
 }
 
 void set_path_item_instruction_start_coords(pbnavitia::PathItem& path_item, const valhalla::midgard::PointLL& instruction_start_coords) {
-    if (!path_item.instruction().empty()) {
-        auto* coords = path_item.mutable_instruction_start_coordinates();
-        coords->set_lat(instruction_start_coords.lat());
-        coords->set_lon(instruction_start_coords.lng());
-    }
+    if (path_item.instruction().empty()) { return; }
+
+    auto* coords = path_item.mutable_instruction_start_coordinates();
+    coords->set_lat(instruction_start_coords.lat());
+    coords->set_lon(instruction_start_coords.lng());
 }
 
 void set_path_item_name(const DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item) {

--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -520,7 +520,7 @@ void compute_path_items(valhalla::Api& api,
         auto const& edge = trip_route.mutable_legs(0)->node(maneuver.begin_path_index()).edge();
 
         auto shape_begin_idx = it->begin_shape_index();
-        const auto& instruction_start_coords = shape[shape_begin_idx];
+        const auto& instruction_start_coord = shape[shape_begin_idx];
 
         set_path_item_type(edge, *path_item);
         set_path_item_name(maneuver, *path_item);
@@ -530,7 +530,7 @@ void compute_path_items(valhalla::Api& api,
         if (enable_instruction) {
             bool is_last_maneuver = std::distance(it, directions_leg.maneuver().end()) == 1;
             set_path_item_instruction(maneuver, *path_item, is_last_maneuver);
-            set_path_item_instruction_start_coords(*path_item, instruction_start_coords);
+            set_path_item_instruction_start_coord(*path_item, instruction_start_coord);
         }
     }
 }
@@ -545,12 +545,12 @@ void set_path_item_instruction(const DirectionsLeg_Maneuver& maneuver, pbnavitia
     }
 }
 
-void set_path_item_instruction_start_coords(pbnavitia::PathItem& path_item, const valhalla::midgard::PointLL& instruction_start_coords) {
+void set_path_item_instruction_start_coord(pbnavitia::PathItem& path_item, const valhalla::midgard::PointLL& instruction_start_coord) {
     if (path_item.instruction().empty()) { return; }
 
-    auto* coords = path_item.mutable_instruction_start_coordinate();
-    coords->set_lat(instruction_start_coords.lat());
-    coords->set_lon(instruction_start_coords.lng());
+    auto* coord = path_item.mutable_instruction_start_coordinate();
+    coord->set_lat(instruction_start_coord.lat());
+    coord->set_lon(instruction_start_coord.lng());
 }
 
 void set_path_item_name(const DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item) {

--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -548,7 +548,7 @@ void set_path_item_instruction(const DirectionsLeg_Maneuver& maneuver, pbnavitia
 void set_path_item_instruction_start_coords(pbnavitia::PathItem& path_item, const valhalla::midgard::PointLL& instruction_start_coords) {
     if (path_item.instruction().empty()) { return; }
 
-    auto* coords = path_item.mutable_instruction_start_coordinates();
+    auto* coords = path_item.mutable_instruction_start_coordinate();
     coords->set_lat(instruction_start_coords.lat());
     coords->set_lon(instruction_start_coords.lng());
 }

--- a/asgard/direct_path_response_builder.h
+++ b/asgard/direct_path_response_builder.h
@@ -50,7 +50,7 @@ void set_path_item_type(const valhalla::TripLeg_Edge& edge, pbnavitia::PathItem&
 void set_path_item_duration(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
 void set_path_item_direction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
 void set_path_item_instruction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item, const bool is_last_maneuver);
-void set_path_item_instruction_start_coords(pbnavitia::PathItem& path_item, const valhalla::midgard::PointLL& instruction_start_coords);
+void set_path_item_instruction_start_coord(pbnavitia::PathItem& path_item, const valhalla::midgard::PointLL& instruction_start_coord);
 
 } // namespace direct_path_response_builder
 } // namespace asgard

--- a/asgard/direct_path_response_builder.h
+++ b/asgard/direct_path_response_builder.h
@@ -50,6 +50,7 @@ void set_path_item_type(const valhalla::TripLeg_Edge& edge, pbnavitia::PathItem&
 void set_path_item_duration(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
 void set_path_item_direction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item);
 void set_path_item_instruction(const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PathItem& path_item, const bool is_last_maneuver);
+void set_path_item_instruction_start_coords(pbnavitia::PathItem& path_item, const valhalla::midgard::PointLL& instruction_start_coords);
 
 } // namespace direct_path_response_builder
 } // namespace asgard

--- a/asgard/tests/direct_path_response_builder_test.cpp
+++ b/asgard/tests/direct_path_response_builder_test.cpp
@@ -325,5 +325,34 @@ BOOST_AUTO_TEST_CASE(set_path_item_duration_test) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(set_path_item_instruction_start_coords_test) {
+    // No value set in path_item
+    {
+        auto instruction_start_coords = midgard::PointLL();
+        auto path_item = pbnavitia::PathItem();
+
+        set_path_item_instruction_start_coords(path_item, instruction_start_coords);
+        BOOST_CHECK_EQUAL(path_item.has_instruction_start_coordinates(), false);
+    }
+
+    // One value set in path_item
+    {
+        DirectionsLeg_Maneuver maneuver;
+        std::string instruction;
+        auto instruction_start_coords = midgard::PointLL();
+        instruction_start_coords.set_x(2.347749f);
+        instruction_start_coords.set_y(48.647623f);
+        auto path_item = pbnavitia::PathItem();
+
+        maneuver.set_text_instruction("Walk east on Avenue de l'Escadrille Normandie-Niemen. Keep going for 35 m.");
+        set_path_item_instruction(maneuver, path_item, true);
+
+        set_path_item_instruction_start_coords(path_item, instruction_start_coords);
+        BOOST_CHECK_EQUAL(path_item.has_instruction_start_coordinates(), true);
+        BOOST_CHECK_EQUAL(path_item.instruction_start_coordinates().lat(), 48.647623f);
+        BOOST_CHECK_EQUAL(path_item.instruction_start_coordinates().lon(), 2.347749f);
+    }
+}
+
 } // namespace direct_path_response_builder
 } // namespace asgard

--- a/asgard/tests/direct_path_response_builder_test.cpp
+++ b/asgard/tests/direct_path_response_builder_test.cpp
@@ -334,13 +334,13 @@ BOOST_AUTO_TEST_CASE(set_path_item_duration_test) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(set_path_item_instruction_start_coords_test) {
+BOOST_AUTO_TEST_CASE(set_path_item_instruction_start_coord_test) {
     // No value set in path_item
     {
-        auto instruction_start_coords = midgard::PointLL();
+        auto instruction_start_coord = midgard::PointLL();
         auto path_item = pbnavitia::PathItem();
 
-        set_path_item_instruction_start_coords(path_item, instruction_start_coords);
+        set_path_item_instruction_start_coord(path_item, instruction_start_coord);
         BOOST_CHECK_EQUAL(path_item.has_instruction_start_coordinate(), false);
     }
 
@@ -348,15 +348,15 @@ BOOST_AUTO_TEST_CASE(set_path_item_instruction_start_coords_test) {
     {
         DirectionsLeg_Maneuver maneuver;
         std::string instruction;
-        auto instruction_start_coords = midgard::PointLL();
-        instruction_start_coords.set_x(2.347749f);
-        instruction_start_coords.set_y(48.647623f);
+        auto instruction_start_coord = midgard::PointLL();
+        instruction_start_coord.set_x(2.347749f);
+        instruction_start_coord.set_y(48.647623f);
         auto path_item = pbnavitia::PathItem();
 
         maneuver.set_text_instruction("Walk east on Avenue de l'Escadrille Normandie-Niemen. Keep going for 35 m.");
         set_path_item_instruction(maneuver, path_item, true);
 
-        set_path_item_instruction_start_coords(path_item, instruction_start_coords);
+        set_path_item_instruction_start_coord(path_item, instruction_start_coord);
         BOOST_CHECK_EQUAL(path_item.has_instruction_start_coordinate(), true);
         BOOST_CHECK_EQUAL(path_item.instruction_start_coordinate().lat(), 48.647623f);
         BOOST_CHECK_EQUAL(path_item.instruction_start_coordinate().lon(), 2.347749f);

--- a/asgard/tests/direct_path_response_builder_test.cpp
+++ b/asgard/tests/direct_path_response_builder_test.cpp
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(set_path_item_instruction_start_coords_test) {
         auto path_item = pbnavitia::PathItem();
 
         set_path_item_instruction_start_coords(path_item, instruction_start_coords);
-        BOOST_CHECK_EQUAL(path_item.has_instruction_start_coordinates(), false);
+        BOOST_CHECK_EQUAL(path_item.has_instruction_start_coordinate(), false);
     }
 
     // One value set in path_item
@@ -357,9 +357,9 @@ BOOST_AUTO_TEST_CASE(set_path_item_instruction_start_coords_test) {
         set_path_item_instruction(maneuver, path_item, true);
 
         set_path_item_instruction_start_coords(path_item, instruction_start_coords);
-        BOOST_CHECK_EQUAL(path_item.has_instruction_start_coordinates(), true);
-        BOOST_CHECK_EQUAL(path_item.instruction_start_coordinates().lat(), 48.647623f);
-        BOOST_CHECK_EQUAL(path_item.instruction_start_coordinates().lon(), 2.347749f);
+        BOOST_CHECK_EQUAL(path_item.has_instruction_start_coordinate(), true);
+        BOOST_CHECK_EQUAL(path_item.instruction_start_coordinate().lat(), 48.647623f);
+        BOOST_CHECK_EQUAL(path_item.instruction_start_coordinate().lon(), 2.347749f);
     }
 }
 


### PR DESCRIPTION
[[Jira ticket](https://jira.kisio.org/browse/NAVP-1723)]
Add the instruction start coordinates to the response builder.
These coordinates could be used to trigger maneuver instructions:

![Capture du 2021-06-08 16-06-48](https://user-images.githubusercontent.com/46373178/121200694-3a037a00-c874-11eb-8810-0be648b2f093.png)
