### PR TITLE
Use fully qualified path in scripts

### DIFF
--- a/scripts/build_asgard_for_ubuntu.sh
+++ b/scripts/build_asgard_for_ubuntu.sh
@@ -6,7 +6,7 @@ usage() { echo "Usage: $0 -a <path_to_asgard_project>" 1>&2; exit 1; }
 while getopts ":a:b:o:" option; do
     case "${option}" in
         a)
-            asgard_dir=${OPTARG}
+            asgard_dir=`realpath ${OPTARG}`
             ;;
     esac
 done

--- a/scripts/create_asgard_data.sh
+++ b/scripts/create_asgard_data.sh
@@ -5,13 +5,13 @@ usage() { echo "Usage: $0 -e <path_to_valhalla_executables> -i <path_of_pbf_dir>
 while getopts ":e:i:o:" option; do
     case "${option}" in
         e)
-            executable_path=${OPTARG}
+            executable_path=`realpath ${OPTARG}`
             ;;
         i)
-            input_dir=${OPTARG}
+            input_dir=`realpath ${OPTARG}`
             ;;
         o)
-            output_dir=${OPTARG}
+            output_dir=`realpath ${OPTARG}`
             ;;
     esac
 done


### PR DESCRIPTION
When relative paths are given in the script inputs, strange things happen.
This just transform the inputs in fully qualified paths. 
See https://linux.die.net/man/1/realpath