### PR TITLE
Handle backward direct path

### DIFF
--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -403,9 +403,32 @@ pbnavitia::Response build_journey_response(const pbnavitia::Request& request,
     default:
         throw std::runtime_error{"Error when determining mono modal, unknow mode: " + mode};
     };
+
+    if (request.direct_path().clockwise() == false) {
+        recompute_date_times_from_arrival(journey, departure_posix_time);
+    }
+
     compute_metadata(*journey);
     LOG_INFO("Direct path response done with mode: " + mode);
     return response;
+}
+
+void recompute_date_times_from_arrival(pbnavitia::Journey* journey,
+                              const time_t arrival_posix_time ) {
+
+
+    journey->set_departure_date_time(arrival_posix_time - time_t(journey->duration()));
+    journey->set_arrival_date_time(arrival_posix_time);
+    auto last_section_arrival_time = arrival_posix_time;
+    auto sections = journey->mutable_sections();
+    for (auto section_iter =  sections->rbegin(); section_iter != sections->rend(); section_iter++) {
+        section_iter->set_end_date_time(last_section_arrival_time);
+        auto begin_date_time = last_section_arrival_time - section_iter->duration();
+        section_iter->set_begin_date_time(begin_date_time);
+        last_section_arrival_time = begin_date_time;
+    }
+
+
 }
 
 void set_extremity_pt_object(const valhalla::midgard::PointLL& geo_point, const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PtObject* o) {

--- a/asgard/direct_path_response_builder.cpp
+++ b/asgard/direct_path_response_builder.cpp
@@ -413,22 +413,17 @@ pbnavitia::Response build_journey_response(const pbnavitia::Request& request,
     return response;
 }
 
-void recompute_date_times_from_arrival(pbnavitia::Journey* journey,
-                              const time_t arrival_posix_time ) {
-
-
+void recompute_date_times_from_arrival(pbnavitia::Journey* journey, const time_t arrival_posix_time) {
     journey->set_departure_date_time(arrival_posix_time - time_t(journey->duration()));
     journey->set_arrival_date_time(arrival_posix_time);
     auto last_section_arrival_time = arrival_posix_time;
     auto sections = journey->mutable_sections();
-    for (auto section_iter =  sections->rbegin(); section_iter != sections->rend(); section_iter++) {
+    for (auto section_iter = sections->rbegin(); section_iter != sections->rend(); section_iter++) {
         section_iter->set_end_date_time(last_section_arrival_time);
         auto begin_date_time = last_section_arrival_time - section_iter->duration();
         section_iter->set_begin_date_time(begin_date_time);
         last_section_arrival_time = begin_date_time;
     }
-
-
 }
 
 void set_extremity_pt_object(const valhalla::midgard::PointLL& geo_point, const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PtObject* o) {

--- a/asgard/direct_path_response_builder.h
+++ b/asgard/direct_path_response_builder.h
@@ -35,8 +35,7 @@ pbnavitia::Response build_journey_response(const pbnavitia::Request& request,
 
 using ConstManeuverItetator = google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg_Maneuver>::const_iterator;
 
-void recompute_date_times_from_arrival(pbnavitia::Journey* journey,
-                              const time_t arrival_posix_time );
+void recompute_date_times_from_arrival(pbnavitia::Journey* journey, const time_t arrival_posix_time);
 
 void set_extremity_pt_object(const valhalla::midgard::PointLL& geo_point, const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PtObject* o);
 void compute_metadata(pbnavitia::Journey& pb_journey);

--- a/asgard/direct_path_response_builder.h
+++ b/asgard/direct_path_response_builder.h
@@ -35,6 +35,9 @@ pbnavitia::Response build_journey_response(const pbnavitia::Request& request,
 
 using ConstManeuverItetator = google::protobuf::RepeatedPtrField<valhalla::DirectionsLeg_Maneuver>::const_iterator;
 
+void recompute_date_times_from_arrival(pbnavitia::Journey* journey,
+                              const time_t arrival_posix_time );
+
 void set_extremity_pt_object(const valhalla::midgard::PointLL& geo_point, const valhalla::DirectionsLeg_Maneuver& maneuver, pbnavitia::PtObject* o);
 void compute_metadata(pbnavitia::Journey& pb_journey);
 void compute_geojson(const std::vector<valhalla::midgard::PointLL>& list_geo_points, pbnavitia::Section& s);

--- a/asgard/tests/direct_path_response_builder_test.cpp
+++ b/asgard/tests/direct_path_response_builder_test.cpp
@@ -68,6 +68,7 @@ BOOST_AUTO_TEST_CASE(build_journey_response_test) {
         valhalla::Api api;
         std::vector<thor::PathInfo> path_info_list = create_path_info_list();
         request.mutable_direct_path()->set_datetime(1470241573);
+        request.mutable_direct_path()->set_clockwise(true);
 
         auto trip_leg = create_trip_leg(api);
 
@@ -103,6 +104,42 @@ BOOST_AUTO_TEST_CASE(build_journey_response_test) {
         BOOST_CHECK_EQUAL(section.destination().name(), "");
         BOOST_CHECK_CLOSE(dest_coords.lon(), 42.0794687f, 0.0001f);
         BOOST_CHECK_CLOSE(dest_coords.lat(), 7.974815640f, 0.0001f);
+    }
+
+    // same as above, but counterclockwise
+    {
+        pbnavitia::Request request;
+        auto* dp = request.mutable_direct_path();
+        auto* params = dp->mutable_streetnetwork_params();
+        params->set_origin_mode("car");
+
+        valhalla::Api api;
+        std::vector<thor::PathInfo> path_info_list = create_path_info_list();
+        request.mutable_direct_path()->set_datetime(1470241573);
+        request.mutable_direct_path()->set_clockwise(false);
+
+        auto trip_leg = create_trip_leg(api);
+
+        auto response = build_journey_response(request, path_info_list, *trip_leg, api);
+        BOOST_CHECK_EQUAL(response.response_type(), pbnavitia::ITINERARY_FOUND);
+        BOOST_CHECK_EQUAL(response.journeys_size(), 1);
+
+        auto const journey = response.journeys(0);
+        BOOST_CHECK_EQUAL(journey.nb_sections(), 1);
+        BOOST_CHECK_EQUAL(journey.nb_transfers(), 0);
+        BOOST_CHECK_EQUAL(journey.duration(), 20);
+        BOOST_CHECK_EQUAL(journey.requested_date_time(), 1470241573);
+        BOOST_CHECK_EQUAL(journey.departure_date_time(), 1470241553);
+        BOOST_CHECK_EQUAL(journey.arrival_date_time(), 1470241573);
+
+        auto const section = journey.sections(0);
+        BOOST_CHECK_EQUAL(section.type(), pbnavitia::STREET_NETWORK);
+        BOOST_CHECK_EQUAL(section.id(), "section_0");
+        BOOST_CHECK_EQUAL(section.duration(), 20);
+        BOOST_CHECK_EQUAL(section.street_network().mode(), pbnavitia::Car);
+        BOOST_CHECK_EQUAL(section.begin_date_time(), 1470241553);
+        BOOST_CHECK_EQUAL(section.end_date_time(), 1470241573);
+        BOOST_CHECK_EQUAL(section.length(), 30);
     }
 }
 

--- a/asgard/tests/handler_test.cpp
+++ b/asgard/tests/handler_test.cpp
@@ -294,7 +294,6 @@ BOOST_AUTO_TEST_CASE(handle_trivial_BSS_with_maneuver_duration_test) {
     }
 }
 
-
 BOOST_AUTO_TEST_CASE(handle_trivial_BSS_counterclockwise_with_maneuver_duration_test) {
     tile_maker::TileMaker maker;
     maker.make_tile();
@@ -315,7 +314,6 @@ BOOST_AUTO_TEST_CASE(handle_trivial_BSS_counterclockwise_with_maneuver_duration_
     auto* dp_request = request.mutable_direct_path();
     dp_request->set_clockwise(false);
     dp_request->set_datetime(744);
-
 
     // Origin is A
     add_origin_or_dest_to_request(dp_request->mutable_origin(),

--- a/asgard/tests/handler_test.cpp
+++ b/asgard/tests/handler_test.cpp
@@ -134,6 +134,7 @@ BOOST_AUTO_TEST_CASE(handle_direct_path_trivial_test) {
     pbnavitia::Request request;
     request.set_requested_api(pbnavitia::direct_path);
     auto* dp_request = request.mutable_direct_path();
+    dp_request->set_clockwise(true);
 
     // Origin is A
     add_origin_or_dest_to_request(dp_request->mutable_origin(),
@@ -218,6 +219,7 @@ BOOST_AUTO_TEST_CASE(handle_trivial_BSS_test) {
     pbnavitia::Request request;
     request.set_requested_api(pbnavitia::direct_path);
     auto* dp_request = request.mutable_direct_path();
+    dp_request->set_clockwise(true);
 
     // Origin is A
     add_origin_or_dest_to_request(dp_request->mutable_origin(),
@@ -261,6 +263,7 @@ BOOST_AUTO_TEST_CASE(handle_trivial_BSS_with_maneuver_duration_test) {
     pbnavitia::Request request;
     request.set_requested_api(pbnavitia::direct_path);
     auto* dp_request = request.mutable_direct_path();
+    dp_request->set_clockwise(true);
 
     // Origin is A
     add_origin_or_dest_to_request(dp_request->mutable_origin(),
@@ -290,4 +293,57 @@ BOOST_AUTO_TEST_CASE(handle_trivial_BSS_with_maneuver_duration_test) {
                                       expected_section_length, expected_section_duration);
     }
 }
+
+
+BOOST_AUTO_TEST_CASE(handle_trivial_BSS_counterclockwise_with_maneuver_duration_test) {
+    tile_maker::TileMaker maker;
+    maker.make_tile();
+
+    zmq::context_t context(1);
+    const Metrics metrics{boost::none};
+    const Projector projector{10, 0, 0};
+
+    boost::property_tree::ptree conf;
+    conf.put("tile_dir", maker.get_tile_dir());
+    valhalla::baldr::GraphReader graph(conf);
+    Context c{context, graph, metrics, projector};
+
+    Handler h{c};
+
+    pbnavitia::Request request;
+    request.set_requested_api(pbnavitia::direct_path);
+    auto* dp_request = request.mutable_direct_path();
+    dp_request->set_clockwise(false);
+    dp_request->set_datetime(744);
+
+
+    // Origin is A
+    add_origin_or_dest_to_request(dp_request->mutable_origin(),
+                                  make_string_from_point(maker.a.second));
+
+    // Destination is i
+    add_origin_or_dest_to_request(dp_request->mutable_destination(),
+                                  make_string_from_point(maker.i.second));
+
+    auto* sn_params = dp_request->mutable_streetnetwork_params();
+    sn_params->set_origin_mode("bss");
+    sn_params->set_walking_speed(2);
+    sn_params->set_bike_speed(4);
+    float rent_duration = 42;
+    float return_duration = 24;
+
+    sn_params->set_bss_rent_duration(rent_duration);
+    sn_params->set_bss_return_duration(return_duration);
+
+    // Last section corresponds to the arrival so its length and duration equal 0
+    std::vector<float> expected_section_length = {111, 0, 1556, 0, 445};
+    std::vector<float> expected_section_duration = {55, rent_duration, 400, return_duration, 222};
+
+    {
+        const auto response = h.handle(request);
+        check_bss_journey_direct_path(response,
+                                      expected_section_length, expected_section_duration);
+    }
+}
+
 } // namespace asgard


### PR DESCRIPTION
To handle a backward direct path, we perform a forward search and then recompute the datetimes from the destination datetime and sections' durations.

@xlqian it was easier than plugging the reverse algorithm from valhalla