### PR TITLE
emaciate dockers

### DIFF
--- a/docker/asgard-app/Dockerfile
+++ b/docker/asgard-app/Dockerfile
@@ -6,13 +6,22 @@ RUN git clone --depth=1 https://github.com/canaltp/asgard asgard
 
 WORKDIR /asgard
 
-# copy libvalhalla in to asgard so that rapidjson is placed in the right place
-RUN cp -r ../libvalhalla libvalhalla
+# create a sym link libvalhalla in to asgard so that rapidjson is placed in the right place
+RUN ln -s ../libvalhalla libvalhalla
 RUN sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules && git submodule update --init --recursive \
   && mkdir build && cd build \
   && cmake -DCMAKE_BUILD_TYPE=Release .. && make -j$(nproc)
 
 FROM ubuntu:20.04
+
+# we install only the depencies that are needed
+RUN apt update && apt install -y wget           \  
+    && apt install -y libboost-regex1.71.0      \ 
+                      libboost-thread1.71.0     \ 
+                      libboost-filesystem1.71.0 \  
+                      libcurl4                  \
+                      libzmq3-dev               \ 
+                      libprotobuf-dev
 
 COPY wait-for-data.sh /usr/bin/wait-for-data.sh
 RUN chmod +x /usr/bin/wait-for-data.sh
@@ -23,8 +32,6 @@ COPY --from=builder /asgard-query /usr/bin/asgard-query
 RUN chmod +x /usr/bin/asgard-query
 USER asgard-user
 COPY --from=builder /asgard/build/asgard/asgard /usr/bin/asgard
-COPY --from=builder /usr/lib/ /usr/lib/
-COPY --from=builder /lib/ /lib/
 EXPOSE 6000 8080
 HEALTHCHECK --interval=60s --timeout=5s --retries=3 \
 CMD /data/valhalla/healthcheck.sh || exit 1

--- a/docker/asgard-build-deps/Dockerfile
+++ b/docker/asgard-build-deps/Dockerfile
@@ -1,53 +1,10 @@
-FROM ubuntu:20.04
+ARG VALHALLA_VERSION=3.1.4
 
-# Now, go through and install the build dependencies
-RUN apt-get update --assume-yes
-RUN env DEBIAN_FRONTEND=noninteractive apt-get install --yes --quiet \
-    autoconf \
-    automake \
-    ccache \
-    clang \
-    clang-format \
-    clang-tidy \
-    coreutils \
-    curl \
-    cmake \
-    g++ \
-    gcc \
-    git \
-    jq \
-    lcov \
-    libboost${boost_version}-all-dev \
-    libcurl4-openssl-dev \
-    libgeos++-dev \
-    libgeos-dev \
-    libluajit-5.1-dev \
-    liblz4-dev \
-    libprotobuf-dev \
-    libspatialite-dev \
-    libsqlite3-dev \
-    libsqlite3-mod-spatialite \
-    libtool \
-    lld \
-    locales \
-    luajit \
-    make \
-    osmium-tool \
-    parallel \
-    pkg-config \
-    protobuf-compiler \
-    python-all-dev \
-    python3-all-dev \
-    python3-minimal \
-    spatialite-bin \
-    unzip \
-    zlib1g-dev \
-    libzmq3-dev \
-    wget \
-    python \
-  && rm -rf /var/lib/apt/lists/*
+FROM valhalla/valhalla:build-${VALHALLA_VERSION}
 
-RUN git clone --branch 3.1.4 --depth=1 https://github.com/valhalla/valhalla.git libvalhalla \
+RUN apt update --assume-yes && apt install -y wget
+
+RUN git clone --branch ${VALHALLA_VERSION} --depth=1 https://github.com/valhalla/valhalla.git libvalhalla \
   && cd libvalhalla \
   && git submodule update --init --recursive --depth=1 \
   && cd -
@@ -57,3 +14,4 @@ RUN mkdir -p libvalhalla/build \
   && cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_SERVICES=Off -DENABLE_NODE_BINDINGS=Off -DENABLE_PYTHON_BINDINGS=Off \
               -DBUILD_SHARED_LIBS=Off -DBoost_USE_STATIC_LIBS=ON -DENABLE_THREAD_SAFE_TILE_REF_COUNT=On\
   && make -j$(nproc) install && ldconfig
+ 

--- a/docker/asgard-valhalla-service/Dockerfile
+++ b/docker/asgard-valhalla-service/Dockerfile
@@ -1,8 +1,27 @@
-FROM valhalla/valhalla:run-3.1.4
+ARG VALHALLA_VERSION=3.1.4
+
+FROM valhalla/valhalla:run-${VALHALLA_VERSION} as builder
+
+
+FROM ubuntu:20.04
+
+RUN apt update && apt install -y software-properties-common
+
+RUN add-apt-repository -y ppa:valhalla-core/valhalla
+
+# we install only the depencies that are needed
+RUN apt install -y libprotobuf-lite17 \
+                   libcurl4 \
+                   prime-server-bin
+
+RUN apt purge -y software-properties-common
+RUN apt autoremove -y
+                                                 
+COPY --from=builder /usr/local/bin/valhalla_service /usr/local/bin/valhalla_service
 
 EXPOSE 8002
 
 COPY wait-for-data.sh /usr/bin/wait-for-data.sh
 RUN chmod +x /usr/bin/wait-for-data.sh
 
-ENTRYPOINT ["sh", "-c", "wait-for-data.sh && valhalla_service /data/valhalla/valhalla.json 1"]
+ENTRYPOINT ["sh", "-c", "valhalla_service /data/valhalla/valhalla.json 1"]

--- a/docker/asgard-valhalla-service/Dockerfile
+++ b/docker/asgard-valhalla-service/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 8002
 COPY wait-for-data.sh /usr/bin/wait-for-data.sh
 RUN chmod +x /usr/bin/wait-for-data.sh
 
-ENTRYPOINT ["sh", "-c", "valhalla_service /data/valhalla/valhalla.json 1"]
+ENTRYPOINT ["sh", "-c", "wait-for-data.sh && valhalla_service /data/valhalla/valhalla.json 1"]


### PR DESCRIPTION
to reduce the size of docker

- Use existent dockers 
- Install minimum dependencies 

asgard-app: from 2.5GB to 250 MB
asgard-valhalla-service: from 1.1GB to 268 MB
